### PR TITLE
caseFile.GetSigners() leads to an invalid enpoint for getting signer …

### DIFF
--- a/Src/Penneo/(Model)/CaseFile.cs
+++ b/Src/Penneo/(Model)/CaseFile.cs
@@ -134,16 +134,19 @@ namespace Penneo
         {
             get
             {
+                return _signers;
+            }
+            set
+            {
+                _signers = value;
                 if (_signers != null)
                 {
-                    foreach(var signer in _signers.Where(x => x.CaseFile == null))
+                    foreach (var signer in _signers)
                     {
                         signer.CaseFile = this;
                     }
                 }
-                return _signers;
             }
-            set { _signers = value; }
         }
 
         /// <summary>
@@ -151,13 +154,9 @@ namespace Penneo
         /// </summary>
         public IEnumerable<Signer> GetSigners()
         {
-            if (_signers == null)
+            if (Signers == null)
             {
-                _signers = GetLinkedEntities<Signer>().Objects.ToList();
-                foreach (var s in _signers)
-                {
-                    s.CaseFile = this;
-                }
+                Signers = GetLinkedEntities<Signer>().Objects.ToList();
             }
             return _signers;
         }

--- a/Src/Penneo/(Model)/CaseFile.cs
+++ b/Src/Penneo/(Model)/CaseFile.cs
@@ -158,7 +158,7 @@ namespace Penneo
             {
                 Signers = GetLinkedEntities<Signer>().Objects.ToList();
             }
-            return _signers;
+            return Signers;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes #41 

Using only GetSigners would bypass the setting of the internal casefile on the signer objects. This has now been moved, so it happens every time the signers collection property is set.
