### PR TITLE
Feat/69/log payload and response

### DIFF
--- a/Src/Penneo/(Model)/Entity.cs
+++ b/Src/Penneo/(Model)/Entity.cs
@@ -128,6 +128,7 @@ namespace Penneo
         /// Get all entities linked with this entity in the storage
         /// </summary>
         protected QueryResult<T> GetLinkedEntities<T>(string url = null)
+            where T: Entity
         {
             return ApiConnector.Instance.GetLinkedEntities<T>(this, url);
         }

--- a/Src/Penneo/(Query)/Query.cs
+++ b/Src/Penneo/(Query)/Query.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Newtonsoft.Json;
 using Penneo.Connector;
 using Penneo.Mapping;
 using RestSharp;
 using Penneo.Util;
+using RestSharp.Contrib;
 
 namespace Penneo
 {
@@ -96,6 +98,10 @@ namespace Penneo
             return output.Objects;
         }
 
+        /// <summary>
+        /// Find entities based on an input object.
+        /// Returns output with data and metadata
+        /// </summary>
         public static QueryResult<T> FindBy<T>(QueryInput input)
             where T : Entity
         {
@@ -127,20 +133,38 @@ namespace Penneo
             }
 
             var output = new QueryResult<T>();
+            output.Input = input;
 
             IEnumerable<T> objects;
             IRestResponse response;
-            output.Success = ApiConnector.Instance.FindBy(query, out objects, out response);
+            output.Success = ApiConnector.Instance.FindBy(query, out objects, out response, input.Page, input.PerPage);
             output.Objects = objects;
             output.StatusCode = response.StatusCode;
             output.ErrorMessage = response.ErrorMessage;
-            
+
             if (output.Success)
             {
+                //Map objects
                 Func<object, object> processor;
                 if (_postProcessors.TryGetValue(typeof (T), out processor))
                 {
                     output.Objects = (IEnumerable<T>) processor(output.Objects);
+                }
+
+                //Pagination
+                output.Page = input.Page;
+                output.PerPage = input.PerPage;
+                var linkHeader = response.Headers.FirstOrDefault(x => x.Name.Equals("link", StringComparison.OrdinalIgnoreCase));
+                if (linkHeader != null && linkHeader.Value != null)
+                {
+                    PaginationUtil.ParseRepsonseHeadersForPagination(linkHeader.Value.ToString(), output);
+                }
+                
+
+                //If no objects were returned, assume that there is no next page - regardless of any returned Link response header
+                if (objects == null || !objects.Any())
+                {
+                    output.NextPage = null;
                 }
             }
             return output;
@@ -162,6 +186,9 @@ namespace Penneo
             }
         }
 
+        /// <summary>
+        /// Get the default message template
+        /// </summary>
         public static QueryResult<MessageTemplate> GetDefaultMessageTemplate()
         {
             var resource = ServiceLocator.Instance.GetInstance<RestResources>().GetResource(typeof(MessageTemplate)) + "/default";
@@ -171,6 +198,9 @@ namespace Penneo
             return new QueryResult<MessageTemplate>(){ Objects = new []{ obj }, Success = true };
         }
 
+        /// <summary>
+        /// Get the current user
+        /// </summary>
         public static QuerySingleObjectResult<User> GetUser()
         {
             IRestResponse response;
@@ -179,6 +209,7 @@ namespace Penneo
         }
 
         private static QuerySingleObjectResult<T> CreateSingleObjectResult<T>(IRestResponse response, T obj, int? id)
+            where T: Entity
         {
             var output = new QuerySingleObjectResult<T>
             {
@@ -198,5 +229,77 @@ namespace Penneo
             return output;
         }
 
+        /// <summary>
+        /// Get the next page based on an earlier result
+        /// </summary>
+        public static QueryResult<T> GetNextPage<T>(QueryResult<T> result)
+            where T: Entity
+        {
+            Log.Write("GetNextPage (" + typeof(T).Name + ")", LogSeverity.Information);
+            if (!result.NextPage.HasValue)
+            {
+                return null;
+            }
+            return GetPage(result, result.NextPage);
+        }
+
+        /// <summary>
+        /// Get the previous page based on an earlier result
+        /// </summary>
+        public static QueryResult<T> GetPreviousPage<T>(QueryResult<T> result)
+            where T : Entity
+        {
+            Log.Write("GetPreviousPage (" + typeof(T).Name + ")", LogSeverity.Information);
+            if (!result.PrevPage.HasValue)
+            {
+                return null;
+            }
+            return GetPage(result, result.PrevPage);
+        }
+
+        /// <summary>
+        /// Get the first page based on an earlier result
+        /// </summary>
+        public static QueryResult<T> GetFirstPage<T>(QueryResult<T> result)
+            where T : Entity
+        {
+            Log.Write("GetFirstPage (" + typeof(T).Name + ")", LogSeverity.Information);
+            if (!result.FirstPage.HasValue)
+            {
+                return null;
+            }
+            return GetPage(result, result.FirstPage);
+        }
+
+        /// <summary>
+        /// Get the first page of a given entity
+        /// </summary>
+        public static QueryResult<T> GetFirstPage<T>(int? perPage = null)
+            where T : Entity
+        {
+            Log.Write("GetFirstPage (" + typeof(T).Name + ")", LogSeverity.Information);
+            var input = new QueryInput();
+            input.Page = 1;
+            input.PerPage = perPage;
+            return FindBy<T>(input);
+        }
+
+        private static void ThrowIfNoPagination<T>(QueryResult<T> result, int? page)
+            where T : Entity
+        {
+            if (!page.HasValue || result.Input == null || !result.Input.Page.HasValue)
+            {
+                throw new NotSupportedException("Cannot use pagination, since the previous request was not using pagination");
+            }
+        }
+
+        private static QueryResult<T> GetPage<T>(QueryResult<T> result, int? page)
+            where T : Entity
+        {
+            ThrowIfNoPagination(result, page);
+            var pageInput = (QueryInput)result.Input.Clone();
+            pageInput.Page = page;
+            return FindBy<T>(pageInput);
+        }
     }
 }

--- a/Src/Penneo/(Query)/QueryInput.cs
+++ b/Src/Penneo/(Query)/QueryInput.cs
@@ -1,14 +1,19 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Penneo
 {
-    public class QueryInput
+    public class QueryInput : ICloneable
     {
         public int Id { get; set; }
         public Dictionary<string, object> Criteria { get; set; }
         public Dictionary<string, string> OrderBy { get; set; }
+        [Obsolete("Use Page and PerPage")]
         public int? Limit { get; set; }
+        [Obsolete("Use Page and PerPage")]
         public int? Offset { get; set; }
+        public int? Page { get; set; }
+        public int? PerPage { get; set; }
 
         public void AddCriteria(string key, object value)
         {
@@ -26,6 +31,21 @@ namespace Penneo
                 OrderBy = new Dictionary<string, string>();
             }
             OrderBy.Add(key, column);
+        }
+
+        public object Clone()
+        {
+            var clone = new QueryInput()
+            {
+                Id = Id,
+                Criteria = Criteria,
+                OrderBy = OrderBy,
+                Limit = Limit,
+                Offset = Offset,
+                Page = Page,
+                PerPage = PerPage
+            };
+            return clone;
         }
     }
 }

--- a/Src/Penneo/(Result)/QueryResult.cs
+++ b/Src/Penneo/(Result)/QueryResult.cs
@@ -3,17 +3,60 @@ using System.Linq;
 
 namespace Penneo
 {
+    /// <summary>
+    /// Query result with multiple fetched objects
+    /// </summary>
     public class QueryResult<T> : ServerResult
+        where T: Entity
     {
+        /// <summary>
+        /// The objects fetched by the executed query
+        /// </summary>
         public IEnumerable<T> Objects { get; set; }
+
+        /// <summary>
+        /// For a query using pagination, this property contains the page number fetched
+        /// </summary>
+        public int? Page { get; set; }
+        /// <summary>
+        /// For a query using pagination, this property contains the number of objects per page
+        /// </summary>
+        public int? PerPage { get; set; }
+        /// <summary>
+        /// For a query using pagination, this property contains the next page number
+        /// </summary>
+        public int? NextPage { get; set; }
+        /// <summary>
+        /// For a query using pagination, this property contains the previous page number
+        /// </summary>
+        public int? PrevPage { get; set; }
+        /// <summary>
+        /// For a query using pagination, this property contains the first page number
+        /// </summary>
+        public int? FirstPage { get; set; }
+
+        /// <summary>
+        /// Query input is stored to facilitate queries with pagination (next page, prev page, etc.)
+        /// </summary>
+        public QueryInput Input { get; set; }
     }
 
+    /// <summary>
+    /// Query result for a single object
+    /// </summary>
     public class QuerySingleObjectResult<T> : ServerResult
+        where T: Entity
     {
+        /// <summary>
+        /// Create an empty result
+        /// </summary>
         public QuerySingleObjectResult()
         {
         }
 
+        /// <summary>
+        /// Create a single object result from a generic query result
+        /// </summary>
         public QuerySingleObjectResult(QueryResult<T> output)
         {
             Success = output.Success;
@@ -23,6 +66,9 @@ namespace Penneo
             }
         }
 
+        /// <summary>
+        /// The single object fetched
+        /// </summary>
         public T Object { get; set; }
     }
 }

--- a/Src/Penneo/Connector/IApiConnector.cs
+++ b/Src/Penneo/Connector/IApiConnector.cs
@@ -54,7 +54,8 @@ namespace Penneo.Connector
         /// <summary>
         /// Gets all entities linked with obj from the backend.
         /// </summary>
-        QueryResult<T> GetLinkedEntities<T>(Entity obj, string url = null);
+        QueryResult<T> GetLinkedEntities<T>(Entity obj, string url = null)
+            where T: Entity;
 
         /// <summary>
         /// Find a specific linked entity
@@ -84,7 +85,7 @@ namespace Penneo.Connector
         /// <summary>
         /// Find objects on the backend based on query parameters
         /// </summary>
-        bool FindBy<T>(Dictionary<string, object> query, out IEnumerable<T> objects, out IRestResponse response)
+        bool FindBy<T>(Dictionary<string, object> query, out IEnumerable<T> objects, out IRestResponse response, int? page = null, int? perPage = null)
             where T : Entity;
 
         /// <summary>
@@ -100,6 +101,6 @@ namespace Penneo.Connector
         /// <summary>
         /// Custom call to the server
         /// </summary>
-        IRestResponse CallServer(string url, Dictionary<string, object> data = null, Method method = Method.GET, Dictionary<string, Dictionary<string, object>> options = null, string customMethod = null);
+        IRestResponse CallServer(string url, Dictionary<string, object> data = null, Method method = Method.GET, Dictionary<string, Dictionary<string, object>> options = null, string customMethod = null, int? page = null, int? perPage = null);
     }
 }

--- a/Src/Penneo/Penneo.csproj
+++ b/Src/Penneo/Penneo.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -58,7 +58,7 @@
     <Compile Include="%28Model%29\MessageTemplate.cs" />
     <Compile Include="%28Model%29\SignerType.cs" />
     <Compile Include="%28Model%29\User.cs" />
-	<Compile Include="%28Model%29\ValidationContents.cs" />
+    <Compile Include="%28Model%29\ValidationContents.cs" />
     <Compile Include="AuthType.cs" />
     <Compile Include="Mapping\Mappings.cs" />
     <Compile Include="%28Model%29\SigningRequest.cs" />
@@ -89,6 +89,7 @@
     <Compile Include="Util\KeyValueMetaDataHelper.cs" />
     <Compile Include="Util\LinqExtensions.cs" />
     <Compile Include="Util\MetaDataExtensions.cs" />
+    <Compile Include="Util\PaginationUtil.cs" />
     <Compile Include="Util\ReflectionUtil.cs" />
     <Compile Include="Util\StringUtil.cs" />
     <Compile Include="Util\TimeUtil.cs" />

--- a/Src/Penneo/Util/PaginationUtil.cs
+++ b/Src/Penneo/Util/PaginationUtil.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Text.RegularExpressions;
+using RestSharp.Contrib;
+
+namespace Penneo.Util
+{
+    public static class PaginationUtil
+    {
+        /// <summary>
+        /// Parses a pagination Link header for next page, previous page, first page and number of objects per page
+        /// Updates the given query result with the parse result
+        /// </summary>
+        public static void ParseRepsonseHeadersForPagination<T>(string linkHeader, QueryResult<T> output)
+            where T : Entity
+        {
+            var relations = linkHeader.ToString().Split(',');
+            foreach (var relation in relations)
+            {
+                var lastIndex = relation.LastIndexOf(";", StringComparison.OrdinalIgnoreCase);
+                var relName = Regex.Match(relation, "rel=\"(?<rel>.*)\"").Groups[1].Value;
+                var relUrl = relation.Substring(0, lastIndex - 1);
+                var parameters = HttpUtility.ParseQueryString(relUrl.Substring(relUrl.IndexOf("?", StringComparison.OrdinalIgnoreCase)));
+                var page = int.Parse(parameters["page"]);
+
+                switch (relName)
+                {
+                    case "next":
+                        output.NextPage = page;
+                        break;
+                    case "prev":
+                        output.PrevPage = page;
+                        break;
+                    case "first":
+                        output.FirstPage = page;
+                        break;
+                }
+
+                var perPage = int.Parse(parameters["per_page"]);
+                output.PerPage = perPage;
+            }
+        }
+    }
+}

--- a/Src/PenneoTests/PaginationTests.cs
+++ b/Src/PenneoTests/PaginationTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using Penneo;
+using Penneo.Connector;
+using Penneo.Util;
+
+namespace PenneoTests
+{
+    [TestFixture]
+    public class PaginationTests
+    {
+        [Test]
+        public void ParseLinkResponseHeaderTest()
+        {
+            var queryResult = new QueryResult<CaseFile>();
+            const string linkHeader = "Link=<https://app.penneo.com/api/v1/casefiles?page=17&per_page=10>; rel=\"next\",<https://app.penneo.com/api/v1/casefiles?page=1&per_page=10>; rel=\"first\",<https://app.penneo.com/api/v1/casefiles?page=15&per_page=10>; rel=\"prev\"";
+            PaginationUtil.ParseRepsonseHeadersForPagination(linkHeader, queryResult);
+            Assert.AreEqual(17, queryResult.NextPage);
+            Assert.AreEqual(15, queryResult.PrevPage);
+            Assert.AreEqual(1, queryResult.FirstPage);
+        }
+
+        [Test]
+        [ExpectedException(typeof(NotSupportedException))]
+        public void PageNotZeroTest()
+        {
+            ApiConnector.SetFactory(null);
+            ((ApiConnector)ApiConnector.Instance).PrepareRequest(string.Empty, page: 0, perPage: 10);
+        }
+
+        [Test]
+        [ExpectedException(typeof(NotSupportedException))]
+        public void PerPageNotZeroTest()
+        {
+            ApiConnector.SetFactory(null);
+            ((ApiConnector)ApiConnector.Instance).PrepareRequest(string.Empty, page: 5, perPage: 0);
+        }
+
+        [Test]
+        [ExpectedException(typeof(NotSupportedException))]
+        public void PageNotLessThanZeroTest()
+        {
+            ApiConnector.SetFactory(null);
+            ((ApiConnector)ApiConnector.Instance).PrepareRequest(string.Empty, page: -2, perPage: 10);
+        }
+
+        [Test]
+        [ExpectedException(typeof(NotSupportedException))]
+        public void PerPageNotLessThanZeroTest()
+        {
+            ApiConnector.SetFactory(null);
+            ((ApiConnector)ApiConnector.Instance).PrepareRequest(string.Empty, page: 5, perPage: -5);
+        }
+
+        [Test]
+        public void PaginateRequestParametersTest()
+        {
+            ApiConnector.SetFactory(null);
+
+            var connector = (ApiConnector) ApiConnector.Instance;
+            var request = connector.PrepareRequest(string.Empty, page: 5, perPage: 10);
+
+            var paginationHeader = request.Parameters.FirstOrDefault(x => x.Name.Equals("x-paginate"));
+            Assert.IsTrue(paginationHeader != null && paginationHeader.Value.ToString().Equals("true", StringComparison.OrdinalIgnoreCase));
+
+            var pageParameter = request.Parameters.FirstOrDefault(x => x.Name.Equals("page"));
+            Assert.IsTrue(pageParameter != null && pageParameter.Value.ToString() == "5");
+
+            var perPageParameter = request.Parameters.FirstOrDefault(x => x.Name.Equals("per_page"));
+            Assert.IsTrue(perPageParameter != null && perPageParameter.Value.ToString() == "10");
+        }
+
+        [Test]
+        public void NoPaginateRequestParametersTest()
+        {
+            ApiConnector.SetFactory(null);
+
+            var connector = (ApiConnector)ApiConnector.Instance;
+            var request = connector.PrepareRequest(string.Empty);
+
+            var paginationHeader = request.Parameters.FirstOrDefault(x => x.Name.Equals("x-paginate"));
+            Assert.IsTrue(paginationHeader == null);
+
+            var pageParameter = request.Parameters.FirstOrDefault(x => x.Name.Equals("page"));
+            Assert.IsTrue(pageParameter == null);
+
+            var perPageParameter = request.Parameters.FirstOrDefault(x => x.Name.Equals("per_page"));
+            Assert.IsTrue(perPageParameter == null);
+        }
+    }
+}

--- a/Src/PenneoTests/PenneoTests.csproj
+++ b/Src/PenneoTests/PenneoTests.csproj
@@ -79,6 +79,7 @@
     <Otherwise />
   </Choose>
   <ItemGroup>
+    <Compile Include="PaginationTests.cs" />
     <Compile Include="QueryTests.cs" />
     <Compile Include="FolderTests.cs" />
     <Compile Include="KeyValueMetaDataTests.cs" />

--- a/Src/PenneoTests/QueryTests.cs
+++ b/Src/PenneoTests/QueryTests.cs
@@ -59,14 +59,14 @@ namespace PenneoTests
             IEnumerable<T> returned = new[] { Activator.CreateInstance<T>() };
             IEnumerable<T> ignoredObjects;
             IRestResponse ignoredResponse;
-            A.CallTo(() => connector.FindBy(null, out ignoredObjects, out ignoredResponse)).WithAnyArguments().Returns(true).AssignsOutAndRefParameters(returned, _response200);
+            A.CallTo(() => connector.FindBy(null, out ignoredObjects, out ignoredResponse, null, null)).WithAnyArguments().Returns(true).AssignsOutAndRefParameters(returned, _response200);
 
             var objects = f();
 
             Assert.IsNotNull(objects);
             CollectionAssert.AreEqual(returned.ToList(), objects.ToList());
 
-            A.CallTo(() => connector.FindBy(null, out objects, out ignoredResponse)).WithAnyArguments().MustHaveHappened();
+            A.CallTo(() => connector.FindBy(null, out objects, out ignoredResponse, null, null)).WithAnyArguments().MustHaveHappened();
         }
 
         private static void FindOneTest<T>(Func<T> f)
@@ -77,14 +77,14 @@ namespace PenneoTests
             IEnumerable<T> returned = new[] { instance };
             IEnumerable<T> ignoredObjects;
             IRestResponse ignoredResponse;
-            A.CallTo(() => connector.FindBy(null, out ignoredObjects, out ignoredResponse)).WithAnyArguments().Returns(true).AssignsOutAndRefParameters(returned, _response200);
+            A.CallTo(() => connector.FindBy(null, out ignoredObjects, out ignoredResponse, null, null)).WithAnyArguments().Returns(true).AssignsOutAndRefParameters(returned, _response200);
 
             var obj = f();
 
             Assert.IsNotNull(obj);
             Assert.AreEqual(instance, obj);
 
-            A.CallTo(() => connector.FindBy(null, out ignoredObjects, out ignoredResponse)).WithAnyArguments().MustHaveHappened();
+            A.CallTo(() => connector.FindBy(null, out ignoredObjects, out ignoredResponse, null, null)).WithAnyArguments().MustHaveHappened();
         }
     }
 }

--- a/Src/PenneoTests/TestUtil.cs
+++ b/Src/PenneoTests/TestUtil.cs
@@ -64,15 +64,16 @@ namespace PenneoTests
             }
             IEnumerable<T> ignoredObjects;
             IRestResponse ignoredResponse;
-            A.CallTo(() => connector.FindBy(null, out ignoredObjects, out ignoredResponse)).WithAnyArguments().Returns(true).AssignsOutAndRefParameters(list, _response200);
+            A.CallTo(() => connector.FindBy(null, out ignoredObjects, out ignoredResponse, null, null)).WithAnyArguments().Returns(true).AssignsOutAndRefParameters(list, _response200);
 
             var result = Query.FindAll<T>().ToList();
 
-            A.CallTo(() => connector.FindBy(null, out ignoredObjects, out ignoredResponse)).WithAnyArguments().MustHaveHappened();
+            A.CallTo(() => connector.FindBy(null, out ignoredObjects, out ignoredResponse, null, null)).WithAnyArguments().MustHaveHappened();
             CollectionAssert.AreEqual(list, result);
         }
 
         public static void TestGetLinked<TChild>(Func<IEnumerable<TChild>> getter)
+            where TChild: Entity
         {
             var connector = CreateFakeConnector();
             var list = new List<TChild>() {Activator.CreateInstance<TChild>()};
@@ -87,6 +88,7 @@ namespace PenneoTests
         }
 
         public static void TestGetLinked<TChild>(Func<TChild> getter)
+            where TChild: Entity
         {
             var connector = CreateFakeConnector();
             var instance = Activator.CreateInstance<TChild>();
@@ -102,6 +104,7 @@ namespace PenneoTests
         }
 
         public static void TestGetLinkedNotCalled<TChild>(Func<TChild> getter)
+            where TChild: Entity
         {
             var connector = CreateFakeConnector();
             var mockedResult = new QueryResult<TChild>() { Objects = new List<TChild>() , StatusCode = HttpStatusCode.OK};


### PR DESCRIPTION
Fixes #69 

Note: Builds on top of pull request #68.

The ILogger interface is the way for a developer to get log messages from the  Penneo.NET sdk (not changed in this pull request). HTTP requests and responses are now sent in detail to the log interface. Using the interface makes it easy for a developer to decide for him/herself what to do with incoming log entries from Penneo.

Developers will get the severity of a log entry through the ILogger interface. So they can skip the "trace" level (for instance) if they do not want to see HTTP details.

Example which only prints out Error and Fatal severities:

internal class Logger : ILogger
{
	public void Log(string message, LogSeverity severity)
	{
		if (severity >= LogSeverity.Error)
		{
			Debug.WriteLine(severity + ": " + message);
		}
	}
}

A given logger is injected into the SDK using the following statement:

PenneoConnector.SetLogger(new MyCustomLogger());

The log severities are defined as follows (not changed in this pull request):

public enum LogSeverity
{
	Trace,
	Information,
	Debug,
	Warning,
	Error,
	Fatal
}