### PR TITLE
Add CaseFile.DisableEmailAttachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 
+## [4.1.0] - 2021-01-21
+### Added
+- Added support for setting CaseFile.DisableEmailAttachments
+
+
 ## [4.0.1] - 2020-12-21
 ### Misc
 - Added support for the net46 platform

--- a/Src/Penneo/(Model)/CaseFile.cs
+++ b/Src/Penneo/(Model)/CaseFile.cs
@@ -151,6 +151,12 @@ namespace Penneo
         public int? CustomerId { get; set; }
 
         /// <summary>
+        /// If set, documents will not be sent as email attachments to signers and the case file owner when the signing
+        /// process is finalized.
+        /// </summary>
+        public bool DisableEmailAttachments = false;
+
+        /// <summary>
         /// The documents in the case file
         /// Note: This property will only return already loaded documents
         /// </summary>

--- a/Src/Penneo/PenneoSetup.cs
+++ b/Src/Penneo/PenneoSetup.cs
@@ -70,6 +70,7 @@ namespace Penneo
                   .Map(x => x.DisableNotificationsOwner)
                   .Map(x => x.SignOnMeeting)
                   .Map(x => x.Reference)
+                  .Map(x => x.DisableEmailAttachments)
                   .Map(x => x.CaseFileTemplate.Id, "caseFileTypeId")
                   .ForUpdate()
                   .Map(x => x.Title)
@@ -81,6 +82,7 @@ namespace Penneo
                   .Map(x => x.VisibilityMode)
                   .Map(x => x.SensitiveData)
                   .Map(x => x.DisableNotificationsOwner)
+                  .Map(x => x.DisableEmailAttachments)
                   .Map(x => x.SignOnMeeting)
                   .Create()
             );


### PR DESCRIPTION
Signed documents are sent as attachments, by default, when a case file is completed. By setting CaseFile.DisableEmailAttachments you can opt out of this functionality.