### PR TITLE
Fix not being able to unmarshal signers vatin.

### DIFF
--- a/Src/Penneo/(Model)/Signer.cs
+++ b/Src/Penneo/(Model)/Signer.cs
@@ -40,6 +40,8 @@ namespace Penneo
         public string SsnType = "legacy";
 
         public string OnBehalfOf { get; set; }
+
+        [JsonProperty(PropertyName = "vatin")]
         public string VATIdentificationNumber { get; set; }
         public CaseFile CaseFile { get; set; }
         public SigningRequest SigningRequest { get; set; }


### PR DESCRIPTION
Hi,

There's a discrepancy between the model returned from the API and mapping done when unmarshalling signers.
Trucated API response
```json
{
  "userId": 1234,
  "customerId": 1234,
  "signers": [
    {
      "name": "Name Name",
      "types": [],
      "sdkClassName": "Signer",
      "id": 1234156,
      "ssnType": "legacy",
      "vatin": "88888888",
      "signingRequest": {
        "sdkClassName": "SigningRequest",
        "id": 1234567,
        "emailSubject": "",
        "emailText": "",
        "reminderEmailSubject": "",
        "reminderEmailText": "",
        "completedEmailSubject": "",
        "completedEmailText": "",
        "emailFormat": "text",
        "status": 0,
        "access Control": true,
        "enableInsecureSigning": false
      },
      "storeAsContact": true
    }
  ]
}
```
