### PR TITLE
Task/SIGN-532 update restsharp and dotnet 6/1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [5.0.0] - 2022-05-04
 ### Changed
-- Updated RestSharp to 108.0.2
-- Updated to .NET 6.0
+- Updated RestSharp from `106.15.0` to `108.0.2`
+- Updated from .NET Core 3.1 to .NET 6.0
 
 ## [4.3.0] - 2022-05-04
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [5.0.0] - 2022-05-04
+### Changed
+- Updated RestSharp to 108.0.2
+- Updated to .NET 6.0
+
 ## [4.3.0] - 2022-05-04
 ### Added
 - Added support for getting different types of default email templates, see [Penneo.MessageTemplate.MessageTemplateType](https://github.com/Penneo/sdk-net/blob/master/Src/Penneo/(Model)/MessageTemplate.cs#L11) for more details

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-## [5.0.0] - 2022-05-04
+## [5.0.0] - 2022-10-18
 ### Changed
 - Updated RestSharp from `106.15.0` to `108.0.2`
 - Updated from .NET Core 3.1 to .NET 6.0

--- a/Src/Penneo/(Model)/WebhookSubscription.cs
+++ b/Src/Penneo/(Model)/WebhookSubscription.cs
@@ -28,7 +28,7 @@ namespace Penneo
         public bool Confirm(PenneoConnector con, string token)
         {
             var data = new Dictionary<string, object> {{"token", token}};
-            return PerformComplexAction(con, Method.POST, "confirm", data).Success;
+            return PerformComplexAction(con, Method.Post, "confirm", data).Success;
         }
     }
 }

--- a/Src/Penneo/Connector/ApiConnector.cs
+++ b/Src/Penneo/Connector/ApiConnector.cs
@@ -420,7 +420,7 @@ namespace Penneo.Connector
 
             _clientOptions = new RestClientOptions(baseUrl: _endpoint)
             {
-                UserAgent = "Penneo_sdk-net_" + Info.Version
+                UserAgent = "Penneo%2Fsdk-net%40" + Info.Version
             };
 
             _client = new RestClient(_clientOptions);

--- a/Src/Penneo/Connector/ApiConnector.cs
+++ b/Src/Penneo/Connector/ApiConnector.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Net;
 using System.Security.Authentication;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Penneo.Util;
@@ -58,6 +59,11 @@ namespace Penneo.Connector
         private RestClient _client;
 
         /// <summary>
+        /// The options for the RestClient
+        /// </summary>
+        private RestClientOptions _clientOptions;
+
+        /// <summary>
         /// Http headers
         /// </summary>
         private Dictionary<string, string> _headers;
@@ -65,7 +71,7 @@ namespace Penneo.Connector
         /// <summary>
         /// The last Http response
         /// </summary>
-        private IRestResponse _lastResponse;
+        private RestResponse _lastResponse;
 
         /// <summary>
         /// Rest resources
@@ -115,24 +121,24 @@ namespace Penneo.Connector
             }
             if (!obj.IsNew)
             {
-                var response = CallServer(obj.GetRelativeUrl(_con) + "/" + obj.Id, data, Method.PUT);
+                var response = CallServer(obj.GetRelativeUrl(_con) + "/" + obj.Id, data, Method.Put).Result;
                 return ExtractResponse(obj, response, result);
             }
             else
             {
-                var response = CallServer(obj.GetRelativeUrl(_con), data, Method.POST);
-                var successfull = ExtractResponse(obj, response, result);
-                if (successfull)
+                var response = CallServer(obj.GetRelativeUrl(_con), data, Method.Post).Result;
+                var successful = ExtractResponse(obj, response, result);
+                if (successful)
                 {
                     //Update id given from server
                     var fromServer = (Entity)JsonConvert.DeserializeObject(response.Content, obj.GetType());
-                    obj.Id = fromServer.Id;
+                    if (fromServer != null) obj.Id = fromServer.Id;
                 }
-                return successfull;
+                return successful;
             }
         }
 
-        private bool ExtractResponse(Entity obj, IRestResponse response, ServerResult result)
+        private bool ExtractResponse(Entity obj, RestResponse response, ServerResult result)
         {
             result.Success = true;
             if (response == null)
@@ -160,17 +166,17 @@ namespace Penneo.Connector
         /// </summary>
         public bool DeleteObject(Entity obj)
         {
-            var response = CallServer(obj.GetRelativeUrl(_con) + '/' + obj.Id, null, Method.DELETE);
+            var response = CallServer(obj.GetRelativeUrl(_con) + '/' + obj.Id, null, Method.Delete).Result;
             return response != null && (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.NoContent);
         }
 
-        public T ReadObject<T>(Entity parent, int? id, out IRestResponse response)
+        public T ReadObject<T>(Entity parent, int? id, out RestResponse response)
             where T : Entity
         {
             return ReadObject<T>(parent, id, null, out response);
         }
 
-        public T ReadObject<T>(Entity parent, int? id, string relativeUrl, out IRestResponse response)
+        public T ReadObject<T>(Entity parent, int? id, string relativeUrl, out RestResponse response)
             where T : Entity
         {
             var url = !string.IsNullOrEmpty(relativeUrl) ? relativeUrl : _restResources.GetResource(typeof(T), parent);
@@ -178,7 +184,7 @@ namespace Penneo.Connector
             {
                 url += "/" + id;
             }
-            response = CallServer(url);
+            response = CallServer(url).Result;
             if (response == null || response.StatusCode != HttpStatusCode.OK)
             {
                 return default(T);
@@ -199,7 +205,7 @@ namespace Penneo.Connector
         public bool LinkEntity(Entity parent, Entity child)
         {
             var url = parent.GetRelativeUrl(_con) + "/" + parent.Id + "/" + _restResources.GetResource(child.GetType()) + "/" + child.Id;
-            var response = CallServer(url, customMethod: "LINK");
+            var response = CallServer(url, method: Method.Post).Result;
             var result = new ServerResult();
             return ExtractResponse(parent, response, result);
         }
@@ -210,7 +216,7 @@ namespace Penneo.Connector
         public bool UnlinkEntity(Entity parent, Entity child)
         {
             var url = parent.GetRelativeUrl(_con) + "/" + parent.Id + "/" + _restResources.GetResource(child.GetType()) + "/" + child.Id;
-            var response = CallServer(url, customMethod: "UNLINK");
+            var response = CallServer(url, method: Method.Delete).Result;
             var result = new ServerResult();
             return ExtractResponse(parent, response, result);
         }
@@ -231,7 +237,7 @@ namespace Penneo.Connector
                 actualUrl = url;
             }
 
-            var response = CallServer(actualUrl);
+            var response = CallServer(actualUrl).Result;
             var result = new QueryResult<T>();
             if (ExtractResponse(obj, response, result))
             {
@@ -256,7 +262,7 @@ namespace Penneo.Connector
                 actualUrl = url;
             }
 
-            var response = CallServer(actualUrl);
+            var response = CallServer(actualUrl).Result;
             var result = new QuerySingleObjectResult<T>();
             if (ExtractResponse(obj, response, result))
             {
@@ -271,7 +277,7 @@ namespace Penneo.Connector
         public T FindLinkedEntity<T>(Entity obj, int id)
         {
             var url = obj.GetRelativeUrl(_con) + "/" + obj.Id + "/" + _restResources.GetResource<T>() + "/" + id;
-            var response = CallServer(url);
+            var response = CallServer(url).Result;
             if (response == null || !_successStatusCodes.Contains(response.StatusCode))
             {
                 throw new Exception("Penneo: Internal problem encountered");
@@ -282,7 +288,7 @@ namespace Penneo.Connector
         public T GetAsset<T>(Entity obj, string assetName)
         {
             var url = obj.GetRelativeUrl(_con) + "/" + obj.Id + "/" + assetName;
-            var response = CallServer(url);
+            var response = CallServer(url).Result;
             if (response == null || string.IsNullOrEmpty(response.Content) || !_successStatusCodes.Contains(response.StatusCode))
             {
                 return default(T);
@@ -306,7 +312,7 @@ namespace Penneo.Connector
         public string GetTextAssets(Entity obj, string assetName)
         {
             var url = obj.GetRelativeUrl(_con) + "/" + obj.Id + "/" + assetName;
-            var response = CallServer(url);
+            var response = CallServer(url).Result;
             var result = JsonConvert.DeserializeObject<string[]>(response.Content);
             return result[0];
         }
@@ -317,7 +323,7 @@ namespace Penneo.Connector
         public IEnumerable<string> GetStringListAsset(Entity obj, string assetName)
         {
             var url = obj.GetRelativeUrl(_con) + "/" + obj.Id + "/" + assetName;
-            var response = CallServer(url);
+            var response = CallServer(url).Result;
             var result = JsonConvert.DeserializeObject<string[]>(response.Content);
             return result;
         }
@@ -325,7 +331,7 @@ namespace Penneo.Connector
         /// <summary>
         /// <see cref="IApiConnector.FindBy{T}"/>
         /// </summary>
-        public bool FindBy<T>(Dictionary<string, object> query, out IEnumerable<T> objects, out IRestResponse response, int? page = null, int? perPage = null)
+        public bool FindBy<T>(Dictionary<string, object> query, out IEnumerable<T> objects, out RestResponse response, int? page = null, int? perPage = null)
             where T : Entity
         {
             var resource = _restResources.GetResource<T>();
@@ -336,7 +342,7 @@ namespace Penneo.Connector
                 options = new Dictionary<string, Dictionary<string, object>>();
                 options["query"] = query;
             }
-            response = CallServer(resource, null, Method.GET, options, page: page, perPage: perPage);
+            response = CallServer(resource, null, Method.Get, options, page: page, perPage: perPage).Result;
             if (response == null || !_successStatusCodes.Contains(response.StatusCode))
             {
                 objects = null;
@@ -352,7 +358,7 @@ namespace Penneo.Connector
         /// </summary>
         public ServerResult PerformAction(Entity obj, string actionName)
         {
-            return PerformComplexAction(obj, Method.PATCH, actionName, null);
+            return PerformComplexAction(obj, Method.Patch, actionName, null);
         }
 
         public ServerResult PerformComplexAction(
@@ -364,7 +370,7 @@ namespace Penneo.Connector
         {
             var result = new ServerResult();
             var url = obj.GetRelativeUrl(_con) + "/" + obj.Id + "/" + action;
-            var response = CallServer(url, data, method);
+            var response = CallServer(url, data, method).Result;
             if (response == null || !_successStatusCodes.Contains(response.StatusCode))
             {
                 result.Success = false;
@@ -412,11 +418,14 @@ namespace Penneo.Connector
                 );
             }
 
-            _client = new RestClient(_endpoint);
-            _client.UserAgent = "Penneo/sdk-net@" + Info.Version;
+            _clientOptions = new RestClientOptions(baseUrl: _endpoint)
+            {
+                UserAgent = "Penneo_sdk-net_" + Info.Version
+            };
+
+            _client = new RestClient(_clientOptions);
 
             _headers = _headers ?? new Dictionary<string, string>();
-            _headers["Content-type"] = "application/json";
 
             if (!string.IsNullOrEmpty(_user))
             {
@@ -464,7 +473,7 @@ namespace Penneo.Connector
         /// <summary>
         /// Prepare a rest request
         /// </summary>
-        internal RestRequest PrepareRequest(string url, Dictionary<string, object> data = null, Method method = Method.GET, Dictionary<string, Dictionary<string, object>> options = null, int? page = null, int? perPage = null)
+        internal RestRequest PrepareRequest(string url, Dictionary<string, object> data = null, Method method = Method.Get, Dictionary<string, Dictionary<string, object>> options = null, int? page = null, int? perPage = null)
         {
             var request = new RestRequest(url, method);
             if (_headers != null)
@@ -499,7 +508,7 @@ namespace Penneo.Connector
                 {
                     throw new NotSupportedException("PerPage must be greater than zero");
                 }
-                request.AddParameter("per_page", perPage);
+                request.AddParameter("per_page", (int) perPage);
             }
             if (page.HasValue)
             {
@@ -507,7 +516,7 @@ namespace Penneo.Connector
                 {
                     throw new NotSupportedException("Page must be greater than zero");
                 }
-                request.AddParameter("page", page);
+                request.AddParameter("page", (int) page);
             }
 
             if (data != null)
@@ -525,7 +534,7 @@ namespace Penneo.Connector
         {
             foreach (var entry in query)
             {
-                request.AddParameter(StringUtil.FirstCharacterToLower(entry.Key), entry.Value);
+                request.AddParameter(StringUtil.FirstCharacterToLower(entry.Key), entry.Value.ToString());
             }
         }
 
@@ -543,37 +552,32 @@ namespace Penneo.Connector
                     if (proxy != null && !_endpoint.Equals(proxy.ToString(), StringComparison.OrdinalIgnoreCase))
                     {
                         _con.Log("Proxy URL: " + proxy, LogSeverity.Information);
-                        _client.Proxy = new WebProxy(proxy);
+                        _clientOptions.Proxy = new WebProxy(proxy);
                     }
                 }
             }
             else
             {
-                _client.Proxy = null;
+                _clientOptions.Proxy = null;
             }
         }
 
         /// <summary>
         /// Calls the Penneo server with a rest request
         /// </summary>
-        public IRestResponse CallServer(string url, Dictionary<string, object> data = null, Method method = Method.GET, Dictionary<string, Dictionary<string, object>> options = null, string customMethod = null, int? page = null, int? perPage = null)
+        public async Task<RestResponse> CallServer(string url, Dictionary<string, object> data = null,
+            Method method = Method.Get, Dictionary<string, Dictionary<string, object>> options = null, int? page = null,
+            int? perPage = null)
         {
             SetProxy();
             try
             {
                 var request = PrepareRequest(url, data, method, options, page, perPage);
-                LogRequest(request, url, customMethod ?? method.ToString());
+                LogRequest(request, url, method.ToString());
 
-                IRestResponse response;
-                if (string.IsNullOrEmpty(customMethod))
-                {
-                    response = _client.Execute(request);
-                }
-                else
-                {
-                    response = _client.ExecuteAsGet(request, customMethod);
-                }
-                LogResponse(response, url, customMethod ?? method.ToString());
+                RestResponse response = await _client.ExecuteAsync(request);
+
+                LogResponse(response, url, method.ToString());
 
                 _lastResponse = response;
                 _wasLastResponseError = !_successStatusCodes.Contains(_lastResponse.StatusCode);
@@ -586,18 +590,18 @@ namespace Penneo.Connector
             }
         }
 
-        private void LogRequest(IRestRequest request, string url, string method)
+        private void LogRequest(RestRequest request, string url, string method)
         {
-            _con.Log(string.Format("HTTP REQUEST {0}: {1}{2} ", method, _client.BaseUrl.ToString(), url), LogSeverity.Trace);
+            _con.Log(string.Format("HTTP REQUEST {0}: {1}{2} ", method, _clientOptions.BaseUrl.ToString(), url), LogSeverity.Trace);
             foreach (var p in request.Parameters)
             {
                 _con.Log(string.Format("{0} - {1}: {2}", p.Type, p.Name, p.Value), LogSeverity.Trace);
             }
         }
 
-        private void LogResponse(IRestResponse response, string url, string method)
+        private void LogResponse(RestResponse response, string url, string method)
         {
-            _con.Log(string.Format("HTTP RESPONSE {0}: {1}{2} ({3} {4}) ", method, _client.BaseUrl.ToString(), url, (int)response.StatusCode, response.StatusCode), LogSeverity.Trace);
+            _con.Log(string.Format("HTTP RESPONSE {0}: {1}{2} ({3} {4}) ", method, _clientOptions.BaseUrl.ToString(), url, (int)response.StatusCode, response.StatusCode), LogSeverity.Trace);
             if (!string.IsNullOrEmpty(response.Content))
             {
                 _con.Log(string.Format("Content:  {0}", response.Content), LogSeverity.Trace);

--- a/Src/Penneo/Connector/IApiConnector.cs
+++ b/Src/Penneo/Connector/IApiConnector.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using RestSharp;
 
 namespace Penneo.Connector
@@ -31,14 +32,14 @@ namespace Penneo.Connector
         /// <summary>
         /// Read an object from the backend
         /// </summary>
-        T ReadObject<T>(Entity parent, int? id, out IRestResponse response)
+        T ReadObject<T>(Entity parent, int? id, out RestResponse response)
             where T : Entity;
 
         /// <summary>
         /// Read an object from the backend
         /// If relative url is specifically provided, then that overrides general resource setup
         /// </summary>
-        T ReadObject<T>(Entity parent, int? id, string relativeUrl, out IRestResponse response)
+        T ReadObject<T>(Entity parent, int? id, string relativeUrl, out RestResponse response)
             where T : Entity;
 
         /// <summary>
@@ -91,7 +92,7 @@ namespace Penneo.Connector
         /// <summary>
         /// Find objects on the backend based on query parameters
         /// </summary>
-        bool FindBy<T>(Dictionary<string, object> query, out IEnumerable<T> objects, out IRestResponse response, int? page = null, int? perPage = null)
+        bool FindBy<T>(Dictionary<string, object> query, out IEnumerable<T> objects, out RestResponse response, int? page = null, int? perPage = null)
             where T : Entity;
 
         /// <summary>
@@ -112,7 +113,8 @@ namespace Penneo.Connector
         /// <summary>
         /// Custom call to the server
         /// </summary>
-        IRestResponse CallServer(string url, Dictionary<string, object> data = null, Method method = Method.GET, Dictionary<string, Dictionary<string, object>> options = null, string customMethod = null, int? page = null, int? perPage = null);
+        Task<RestResponse> CallServer(string url, Dictionary<string, object> data = null, Method method = Method.Get,
+            Dictionary<string, Dictionary<string, object>> options = null, int? page = null, int? perPage = null);
 
         /// <summary>
         /// Change the key and secret on the api connector

--- a/Src/Penneo/Connector/WSSEAuthenticator.cs
+++ b/Src/Penneo/Connector/WSSEAuthenticator.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading.Tasks;
 using RestSharp;
 using RestSharp.Authenticators;
 
@@ -47,7 +48,7 @@ namespace Penneo.Connector
         /// <summary>
         /// Adds WSSE security headers to the request
         /// </summary>        
-        public void Authenticate(IRestClient client, IRestRequest request)
+        public ValueTask Authenticate(RestClient client, RestRequest request)
         {
             var created = DateTime.Now.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
             var nonce = Base64Encode(Noncer());
@@ -60,6 +61,7 @@ namespace Penneo.Connector
                 nonce,
                 created
                 ));
+            return default;
         }
 
         #endregion

--- a/Src/Penneo/Info.cs
+++ b/Src/Penneo/Info.cs
@@ -5,6 +5,6 @@ namespace Penneo
         /// <summary>
         /// The version of the SDK. This should be updated on each release.
         /// </summary>
-        public const string Version = "4.3.0";
+        public const string Version = "5.0.0";
     }
 }

--- a/Src/Penneo/Penneo.csproj
+++ b/Src/Penneo/Penneo.csproj
@@ -2,7 +2,7 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
  
-    <Version>3.0.0</Version>
+    <Version>5.0.0</Version>
     <PackageId>Penneo.SDK</PackageId>
     <OutputType>Library</OutputType>
     <PackageLicenseUrl>https://github.com/Penneo/sdk-net/blob/master/license.txt</PackageLicenseUrl>
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="RestSharp" Version="106.15.0" />
+    <PackageReference Include="RestSharp" Version="108.0.2" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'== 'net46'">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.2">

--- a/Src/Penneo/Penneo.csproj
+++ b/Src/Penneo/Penneo.csproj
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net46</TargetFrameworks>
  
     <Version>3.0.0</Version>
     <PackageId>Penneo.SDK</PackageId>
@@ -21,6 +20,7 @@
     <Copyright>Copyright 2020</Copyright>
     <TargetFrameworkProfile />
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Src/Penneo/Penneo.csproj
+++ b/Src/Penneo/Penneo.csproj
@@ -46,7 +46,7 @@
     <PackageReference Include="RestSharp" Version="106.15.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'== 'net46'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.0">
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net46" Version="1.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Src/Penneo/RestConnector.cs
+++ b/Src/Penneo/RestConnector.cs
@@ -31,9 +31,9 @@ namespace Penneo
         /// <summary>
         /// Send a custom request to the Penneo backend
         /// </summary>
-        public IRestResponse InvokeRequest(string url, Dictionary<string, object> body = null, Method method = Method.GET, Dictionary<string, Dictionary<string, object>> options = null, string customMethod = null, int? page = null, int? perPage = null)
+        public RestResponse InvokeRequest(string url, Dictionary<string, object> body = null, Method method = Method.Get, Dictionary<string, Dictionary<string, object>> options = null, int? page = null, int? perPage = null)
         {
-            return _con.ApiConnector.CallServer(url, body, method, options, customMethod, page, perPage);
+            return _con.ApiConnector.CallServer(url, body, method, options, page, perPage).Result;
         }
 
         /// <summary>

--- a/Src/PenneoTests/PenneoTests.csproj
+++ b/Src/PenneoTests/PenneoTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     </PropertyGroup>

--- a/Src/PenneoTests/PenneoTests.csproj
+++ b/Src/PenneoTests/PenneoTests.csproj
@@ -19,10 +19,9 @@
         <PackageReference Include="NUnit" Version="3.12.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-        <PackageReference Include="FakeItEasy" Version="6.2.1" />
+        <PackageReference Include="FakeItEasy" Version="7.3.1" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-        <PackageReference Include="RestSharp" Version="106.15.0" />
-        <PackageReference Include="NUnit" Version="3.12.0" />
+        <PackageReference Include="RestSharp" Version="108.0.2" />
     </ItemGroup>
     <Choose>
         <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">

--- a/Src/PenneoTests/QueryTests.cs
+++ b/Src/PenneoTests/QueryTests.cs
@@ -12,13 +12,13 @@ namespace PenneoTests
     [TestFixture]
     public class QueryTests
     {
-        private static IRestResponse _response200 = new RestResponse { StatusCode = HttpStatusCode.OK};
+        private static RestResponse _response200 = new RestResponse { StatusCode = HttpStatusCode.OK};
 
         [Test]
         public void FindTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            IRestResponse ignoredResponse;
+            RestResponse ignoredResponse;
             var expected = new CaseFile( "Test"){ Id = 1 };
             A.CallTo(() => con.ApiConnector.ReadObject<CaseFile>(null, 1, out ignoredResponse)).WithAnyArguments().Returns(expected).AssignsOutAndRefParameters(_response200);
 
@@ -64,7 +64,7 @@ namespace PenneoTests
         {
             IEnumerable<T> returned = new[] { (T)Activator.CreateInstance(typeof(T)) };
             IEnumerable<T> ignoredObjects;
-            IRestResponse ignoredResponse;
+            RestResponse ignoredResponse;
             A.CallTo(() => con.ApiConnector.FindBy(null, out ignoredObjects, out ignoredResponse, null, null)).WithAnyArguments().Returns(true).AssignsOutAndRefParameters(returned, _response200);
 
             var objects = f();
@@ -81,7 +81,7 @@ namespace PenneoTests
             var instance = (T) Activator.CreateInstance(typeof(T));
             IEnumerable<T> returned = new[] { instance };
             IEnumerable<T> ignoredObjects;
-            IRestResponse ignoredResponse;
+            RestResponse ignoredResponse;
             A.CallTo(() => con.ApiConnector.FindBy(null, out ignoredObjects, out ignoredResponse, null, null)).WithAnyArguments().Returns(true).AssignsOutAndRefParameters(returned, _response200);
 
             var obj = f();

--- a/Src/PenneoTests/TestUtil.cs
+++ b/Src/PenneoTests/TestUtil.cs
@@ -12,7 +12,7 @@ namespace PenneoTests
 {
     internal static class TestUtil
     {
-        private static IRestResponse _response200 = new RestResponse { StatusCode = HttpStatusCode.OK };
+        private static RestResponse _response200 = new RestResponse { StatusCode = HttpStatusCode.OK };
 
         public static PenneoConnector CreatePenneoConnector()
         {
@@ -71,7 +71,7 @@ namespace PenneoTests
                 list[i].Id = i;
             }
             IEnumerable<T> ignoredObjects;
-            IRestResponse ignoredResponse;
+            RestResponse ignoredResponse;
             A.CallTo(() => con.ApiConnector.FindBy(null, out ignoredObjects, out ignoredResponse, null, null)).WithAnyArguments().Returns(true).AssignsOutAndRefParameters(list, _response200);
 
             var q = new Query(con);

--- a/scripts/linux/runtests.sh
+++ b/scripts/linux/runtests.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-dotnet vstest Src/PenneoTests/bin/Debug/netcoreapp3.1/PenneoTests.dll
+dotnet vstest Src/PenneoTests/bin/Debug/net6.0/PenneoTests.dll


### PR DESCRIPTION
## Description
<!-- Overview of the work done -->
This PR will update RestSharp package to `108.0.2`. It also updates the target framework to `net6.0` from `netcoreapp3.1` because LTS for `netcoreapp3.1` will [end on December 13, 2022](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle). 

## Technical details
<!-- Things worth mentioning about the implementation -->
### RestSharp made some [fairly big changes in v107](https://restsharp.dev/v107/#restsharp-v107) with the biggest being the removal of IRestClient and IRestRequest moving many of their members elsewhere in the API so here are some of the highlights: 

- I've added `_clientOptions` to `ApiConnector.cs`

- I've also removed the manual setting of the Content-Type header as the RestSharp documentation specifically recommends not using it as [RestSharp automatically sets the correct Content-Type.](https://restsharp.dev/usage.html#http-header) 

#### [`CallServer()` in ApiConnector.cs](https://github.com/Penneo/sdk-net/pull/152/files#diff-8f6461ceb7f2b416ce8097eb13d8a1ee4bbc67830bf2387834fc3c3058a5b419R568) has also been changed significantly:

- I removed the `customMethod` parameter as it is no longer needed; this parameter was only [used by the LinkEntity()](https://github.com/Penneo/sdk-net/pull/152/files#diff-8f6461ceb7f2b416ce8097eb13d8a1ee4bbc67830bf2387834fc3c3058a5b419R208) which now uses the correct `Method.Post` instead. 
- `CallServer()` is now an async method and returns `Task<RestResponse>` meaning the result now should be accessed via`var response = CallServer.(resource).Result;`