### PR TITLE
Add/allow base64 as document/0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [5.1.2] - 2023-02-09
+### Added
+- Added support for using base64 strings instead of filepath for document pdfs
+
 ## [5.1.1] - 2022-11-22
 ### Fixed
 - Fixed an issue that made it impossible to add activation and expiration dates to signature lines

--- a/Nuget/Penneo.nuspec
+++ b/Nuget/Penneo.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Penneo.SDK</id>
-    <version>5.1.1</version>
+    <version>5.1.2</version>
     <title>Penneo .Net SDK</title>
     <authors>Penneo</authors>
     <owners>Penneo</owners>

--- a/Src/Penneo/(Model)/Document.cs
+++ b/Src/Penneo/(Model)/Document.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -31,7 +32,7 @@ namespace Penneo
             CaseFile = cf;
         }
 
-        public Document(CaseFile cf, string title, string pdfFilePath)
+        public Document(CaseFile cf, string title, string pdfFilePath, string base64File = null)
             : this(cf)
         {
             CaseFile = cf;
@@ -56,6 +57,11 @@ namespace Penneo
         /// Reference to the pdf file on disk, which will be uploaded to the document
         /// </summary>
         public string PdfFile { get; set; }
+        
+        /// <summary>
+        /// The pdf file as base64 string, if set PdfFile parameter will be ignored
+        /// </summary>
+        public string Base64File { get; set; }
 
         /// <summary>
         /// The raw byte array of the pdf
@@ -64,7 +70,11 @@ namespace Penneo
         {
             get
             {
-                if (_pdfRaw == null && !string.IsNullOrEmpty(PdfFile) && File.Exists(PdfFile))
+                if (_pdfRaw == null && !string.IsNullOrEmpty(Base64File))
+                {
+                    _pdfRaw = Convert.FromBase64String(Base64File);
+                }
+                else if (_pdfRaw == null && !string.IsNullOrEmpty(PdfFile) && File.Exists(PdfFile))
                 {
                     _pdfRaw = File.ReadAllBytes(PdfFile);
                 }

--- a/Src/Penneo/(Model)/Document.cs
+++ b/Src/Penneo/(Model)/Document.cs
@@ -32,12 +32,21 @@ namespace Penneo
             CaseFile = cf;
         }
 
-        public Document(CaseFile cf, string title, string pdfFilePath, string base64File = null)
+        public Document(CaseFile cf, string title, string pdfFile)
             : this(cf)
         {
             CaseFile = cf;
             Title = title;
-            PdfFile = pdfFilePath;
+            
+            byte[] buffer = new byte[pdfFile.Length * 3 / 4];
+            if (Convert.TryFromBase64String(pdfFile, buffer, out _))
+            {
+                PdfRaw = buffer;
+            }
+            else if (!string.IsNullOrEmpty(pdfFile) && File.Exists(pdfFile))
+            {
+                PdfFile = pdfFile;
+            }
         }
 
         /// <summary>
@@ -70,20 +79,13 @@ namespace Penneo
         {
             get
             {
-                if (_pdfRaw == null && !string.IsNullOrEmpty(Base64File))
-                {
-                    _pdfRaw = Convert.FromBase64String(Base64File);
-                }
-                else if (_pdfRaw == null && !string.IsNullOrEmpty(PdfFile) && File.Exists(PdfFile))
+                if (_pdfRaw == null && !string.IsNullOrEmpty(PdfFile) && File.Exists(PdfFile))
                 {
                     _pdfRaw = File.ReadAllBytes(PdfFile);
                 }
                 return _pdfRaw;
             }
-            set
-            {
-                _pdfRaw = value;
-            }
+            set => _pdfRaw = value;
         }
 
         /// <summary>

--- a/Src/Penneo/Info.cs
+++ b/Src/Penneo/Info.cs
@@ -5,6 +5,6 @@ namespace Penneo
         /// <summary>
         /// The version of the SDK. This should be updated on each release.
         /// </summary>
-        public const string Version = "5.1.1";
+        public const string Version = "5.1.2";
     }
 }

--- a/Src/Penneo/Penneo.csproj
+++ b/Src/Penneo/Penneo.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     
-    <Version>5.0.1</Version>
+    <Version>5.1.2</Version>
     <PackageId>Penneo.SDK</PackageId>
     <OutputType>Library</OutputType>
     <PackageLicenseUrl>https://github.com/Penneo/sdk-net/blob/master/license.txt</PackageLicenseUrl>


### PR DESCRIPTION
This PR aims to add support for using base64 strings as the pdf file for new Documents.

It achieves this by using the `Convert.TryFromBase64String()` to convert the provided pdfFile argument as a Base64 string. If the method returns false it defaults to the old behavior and tries to read the argument as a file path.   