### PR TITLE
Fix/fixing unit tests

### DIFF
--- a/Src/Penneo/(Model)/Contact.cs
+++ b/Src/Penneo/(Model)/Contact.cs
@@ -1,8 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Newtonsoft.Json;
-
-namespace Penneo
+﻿namespace Penneo
 {
     public class Contact : Entity
     {

--- a/Src/Penneo/(Model)/CopyRecipient.cs
+++ b/Src/Penneo/(Model)/CopyRecipient.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace Penneo
+﻿namespace Penneo
 {
     public class CopyRecipient : Entity
     {

--- a/Src/Penneo/(Model)/Document.cs
+++ b/Src/Penneo/(Model)/Document.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Buffers.Text;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,7 +6,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Penneo.Connector;
-using Penneo.Util;
 
 namespace Penneo
 {

--- a/Src/Penneo/(Model)/DocumentType.cs
+++ b/Src/Penneo/(Model)/DocumentType.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using Newtonsoft.Json;
+﻿using System.Collections.Generic;
 
 namespace Penneo
 {

--- a/Src/Penneo/(Model)/SignerType.cs
+++ b/Src/Penneo/(Model)/SignerType.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Penneo
+﻿namespace Penneo
 {
     public class SignerType : Entity
     {

--- a/Src/Penneo/(Model)/Validation.cs
+++ b/Src/Penneo/(Model)/Validation.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 
 namespace Penneo
 {

--- a/Src/Penneo/(Model)/ValidationContents.cs
+++ b/Src/Penneo/(Model)/ValidationContents.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Newtonsoft.Json;
 using Penneo.Connector;
 

--- a/Src/Penneo/(Query)/Query.cs
+++ b/Src/Penneo/(Query)/Query.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Penneo.Connector;

--- a/Src/Penneo/Connector/ApiConnector.cs
+++ b/Src/Penneo/Connector/ApiConnector.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Net;
-using System.Security.Authentication;
-using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Penneo.Util;
 using RestSharp;
 

--- a/Src/Penneo/Mapping/MethodProperties.cs
+++ b/Src/Penneo/Mapping/MethodProperties.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.CodeDom;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using Penneo.Util;

--- a/Src/Penneo/PenneoConnector.cs
+++ b/Src/Penneo/PenneoConnector.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Penneo.Connector;
-using Penneo.Mapping;
-using Penneo.Util;
 
 namespace Penneo
 {

--- a/Src/Penneo/PenneoSetup.cs
+++ b/Src/Penneo/PenneoSetup.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Penneo.Connector;
 using Penneo.Mapping;
 using Penneo.Util;

--- a/Src/Penneo/RestConnector.cs
+++ b/Src/Penneo/RestConnector.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
-using Penneo.Connector;
 using RestSharp;
 
 namespace Penneo

--- a/Src/PenneoTests/CaseFileTests.cs
+++ b/Src/PenneoTests/CaseFileTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Penneo;
@@ -17,44 +18,44 @@ namespace PenneoTests
         }
 
         [Test]
-        public void PersistSuccessTest()
+        public async Task PersistSuccessTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersist(con, () => new CaseFile());
+            await TestUtil.TestPersist(con, () => new CaseFile());
         }
 
         [Test]
-        public void PersistFailTest()
+        public async Task PersistFailTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersistFail(con, () => new CaseFile());
+            await TestUtil.TestPersistFail(con, () => new CaseFile());
         }
 
         [Test]
-        public void DeleteTest()
+        public async Task DeleteTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestDelete(con, () => new CaseFile());
+            await TestUtil.TestDelete(con, () => new CaseFile());
         }
 
         [Test]
-        public void GetTest()
+        public async Task GetTest()
         {
-            TestUtil.TestGet<CaseFile>();
+            await TestUtil.TestGet<CaseFile>();
         }
 
         [Test]
-        public void GetDocumentsTest()
+        public async Task GetDocumentsTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestGetLinked(con, () => new CaseFile().GetDocumentsAsync(con));
+            await TestUtil.TestGetLinked(con, () => new CaseFile().GetDocumentsAsync(con));
         }
 
         [Test]
-        public void GetSignersTest()
+        public async Task GetSignersTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestGetLinked(con, () => new CaseFile().GetSignersAsync(con));
+            await TestUtil.TestGetLinked(con, () => new CaseFile().GetSignersAsync(con));
         }
 
         [Test]
@@ -65,17 +66,17 @@ namespace PenneoTests
         }
 
         [Test]
-        public void SendTest()
+        public async Task SendTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPerformActionSuccess(con, () => new CaseFile().SendAsync(con));
+            await TestUtil.TestPerformActionSuccess(con, () => new CaseFile().SendAsync(con));
         }
         
         [Test]
-        public void ActivateTest()
+        public async Task ActivateTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPerformActionSuccess(con, () => new CaseFile().ActivateAsync(con));
+            await TestUtil.TestPerformActionSuccess(con, () => new CaseFile().ActivateAsync(con));
         }
 
         [Test]

--- a/Src/PenneoTests/ContactTest.cs
+++ b/Src/PenneoTests/ContactTest.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Linq;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Penneo;

--- a/Src/PenneoTests/ContactTest.cs
+++ b/Src/PenneoTests/ContactTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Threading.Tasks;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using Penneo;
@@ -17,30 +18,30 @@ namespace PenneoTests
         }
 
         [Test]
-        public void PersistSuccessTest()
+        public async Task PersistSuccessTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersist(con, () => new Contact());
+            await TestUtil.TestPersist(con, () => new Contact());
         }
 
         [Test]
-        public void PersistFailTest()
+        public async Task PersistFailTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersistFail(con, () => new Contact());
+            await TestUtil.TestPersistFail(con, () => new Contact());
         }
 
         [Test]
-        public void DeleteTest()
+        public async Task DeleteTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestDelete(con, () => new Contact());
+            await TestUtil.TestDelete(con, () => new Contact());
         }
 
         [Test]
-        public void GetTest()
+        public async Task GetTest()
         {
-            TestUtil.TestGet<Contact>();
+            await TestUtil.TestGet<Contact>();
         }
 
         [Test]

--- a/Src/PenneoTests/DocumentTests.cs
+++ b/Src/PenneoTests/DocumentTests.cs
@@ -56,30 +56,30 @@ namespace PenneoTests
         }
 
         [Test]
-        public void PersistSuccessTest()
+        public async Task PersistSuccessTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersist(con, CreateDocument);
+            await TestUtil.TestPersist(con, CreateDocument);
         }
 
         [Test]
-        public void PersistFailTest()
+        public async Task PersistFailTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersistFail(con, CreateDocument);
+            await TestUtil.TestPersistFail(con, CreateDocument);
         }
 
         [Test]
-        public void DeleteTest()
+        public async Task DeleteTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestDelete(con, CreateDocument);
+            await TestUtil.TestDelete(con, CreateDocument);
         }
 
         [Test]
-        public void GetTest()
+        public async Task GetTest()
         {
-            TestUtil.TestGet<Document>();
+            await TestUtil.TestGet<Document>();
         }
 
         [Test]
@@ -114,7 +114,7 @@ namespace PenneoTests
         }
 
         [Test]
-        public void SavePdfTest()
+        public async Task SavePdfTest()
         {
             var con = TestUtil.CreatePenneoConnector();
             var data = File.ReadAllBytes(TestPdfPath);
@@ -124,8 +124,8 @@ namespace PenneoTests
             var savePath = Path.GetTempFileName();
             try
             {
-                doc.SavePdfAsync(con, savePath);
-                var readBytes = File.ReadAllBytes(savePath);
+                await doc.SavePdfAsync(con, savePath);
+                var readBytes = await File.ReadAllBytesAsync(savePath);
                 CollectionAssert.AreEqual(data, readBytes);
             }
             finally
@@ -137,8 +137,8 @@ namespace PenneoTests
             var savePath2 = Path.GetTempFileName();
             try
             {
-                doc2.SavePdfAsync(con, savePath);
-                var readBytes = File.ReadAllBytes(savePath);
+                await doc2.SavePdfAsync(con, savePath);
+                var readBytes = await File.ReadAllBytesAsync(savePath);
                 CollectionAssert.AreEqual(data, readBytes);
             }
             finally
@@ -154,7 +154,7 @@ namespace PenneoTests
         {
             var con1 = TestUtil.CreatePenneoConnector();
             var doc1 = CreateDocument();
-            TestUtil.TestGetLinked(con1,  () => doc1.GetDocumentTypeAsync(con1));
+            await TestUtil.TestGetLinked(con1,  () => doc1.GetDocumentTypeAsync(con1));
 
             var con2 = TestUtil.CreatePenneoConnector();
             var doc2 = new Document();

--- a/Src/PenneoTests/FolderTests.cs
+++ b/Src/PenneoTests/FolderTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
 using Penneo;
 
 namespace PenneoTests
@@ -14,30 +15,30 @@ namespace PenneoTests
         }
 
         [Test]
-        public void PersistSuccessTest()
+        public async Task PersistSuccessTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersist(con, () => new Folder());
+            await TestUtil.TestPersist(con, () => new Folder());
         }
 
         [Test]
-        public void PersistFailTest()
+        public async Task PersistFailTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersistFail(con, () => new Folder());
+            await TestUtil.TestPersistFail(con, () => new Folder());
         }
 
         [Test]
-        public void DeleteTest()
+        public async Task DeleteTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestDelete(con, () => new Folder());
+            await TestUtil.TestDelete(con, () => new Folder());
         }
 
         [Test]
-        public void GetTest()
+        public async Task GetTest()
         {
-            TestUtil.TestGet<Folder>();
+            await TestUtil.TestGet<Folder>();
         }
 
         [Test]

--- a/Src/PenneoTests/KeyValueMetaDataTests.cs
+++ b/Src/PenneoTests/KeyValueMetaDataTests.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Text;
-using Newtonsoft.Json;
 using NUnit.Framework;
-using Penneo;
 using Penneo.Util;
 
 namespace PenneoTests

--- a/Src/PenneoTests/QueryTests.cs
+++ b/Src/PenneoTests/QueryTests.cs
@@ -39,11 +39,11 @@ namespace PenneoTests
         }
 
         [Test]
-        public void FindOneByTest()
+        public async Task FindOneByTest()
         {
             var con = TestUtil.CreatePenneoConnector();
             var q = new Query(con);
-            FindOneTest(con, () => q.FindOneByAsync<CaseFile>());
+            await FindOneTest(con, () => q.FindOneByAsync<CaseFile>());
         }
 
         [Test]
@@ -89,8 +89,7 @@ namespace PenneoTests
             IEnumerable<T> returned = new[] { instance };
             A.CallTo(() => con.ApiConnector.FindByAsync<T>(null, null, null)).WithAnyArguments()
                 .Returns(Task.FromResult(new FindByResult<T>
-                    { Success = true, Objects = returned, Response = _response200 }))
-                .AssignsOutAndRefParameters(returned, _response200);
+                    { Success = true, Objects = returned, Response = _response200 }));
 
             var obj = await f();
 

--- a/Src/PenneoTests/SignatureLineTests.cs
+++ b/Src/PenneoTests/SignatureLineTests.cs
@@ -32,34 +32,34 @@ namespace PenneoTests
         }
 
         [Test]
-        public void PersistSuccessTest()
+        public async Task PersistSuccessTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersist(con, CreateSignatureLine);
+            await TestUtil.TestPersist(con, CreateSignatureLine);
         }
 
         [Test]
-        public void PersistFailTest()
+        public async Task PersistFailTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersistFail(con, CreateSignatureLine);
+            await TestUtil.TestPersistFail(con, CreateSignatureLine);
         }
 
         [Test]
-        public void DeleteTest()
+        public async Task DeleteTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestDelete(con, CreateSignatureLine);
+            await TestUtil.TestDelete(con, CreateSignatureLine);
         }
 
         [Test]
-        public void GetTest()
+        public async Task GetTest()
         {
-            TestUtil.TestGet<SignatureLine>();
+            await TestUtil.TestGet<SignatureLine>();
         }
 
         [Test]
-        public void SetSignerSuccessTest()
+        public async Task SetSignerSuccessTest()
         {
             var con = TestUtil.CreatePenneoConnector();
             var sl = CreateSignatureLine();
@@ -67,7 +67,7 @@ namespace PenneoTests
 
             A.CallTo(() => con.ApiConnector.LinkEntityAsync(sl, s)).Returns(true);
 
-            sl.SetSignerAsync(con, s);
+            await sl.SetSignerAsync(con, s);
 
             Assert.AreEqual(s, sl.Signer);
             A.CallTo(() => con.ApiConnector.LinkEntityAsync(sl, s)).MustHaveHappened();

--- a/Src/PenneoTests/SignerTests.cs
+++ b/Src/PenneoTests/SignerTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
 using Penneo;
 
 namespace PenneoTests
@@ -25,37 +26,37 @@ namespace PenneoTests
         }
 
         [Test]
-        public void PersistSuccessTest()
+        public async Task PersistSuccessTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersist(con, CreateSigner);
+            await TestUtil.TestPersist(con, CreateSigner);
         }
 
         [Test]
-        public void PersistFailTest()
+        public async Task PersistFailTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersistFail(con, CreateSigner);
+            await TestUtil.TestPersistFail(con, CreateSigner);
         }
 
         [Test]
-        public void DeleteTest()
+        public async Task DeleteTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestDelete(con, CreateSigner);
+            await TestUtil.TestDelete(con, CreateSigner);
         }
 
         [Test]
-        public void GetTest()
+        public async Task GetTest()
         {
-            TestUtil.TestGet<Signer>();
+            await TestUtil.TestGet<Signer>();
         }
 
         [Test]
-        public void GetSigningRequestTest()
+        public async Task GetSigningRequestTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestGetLinked(con, () => CreateSigner().GetSigningRequest(con));
+            await TestUtil.TestGetLinked(con, () => CreateSigner().GetSigningRequest(con));
         }        
     }
 }

--- a/Src/PenneoTests/SigningRequestTests.cs
+++ b/Src/PenneoTests/SigningRequestTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
 using Penneo;
 
 namespace PenneoTests
@@ -7,30 +8,30 @@ namespace PenneoTests
     public class SigningRequestTests
     {        
         [Test]
-        public void PersistSuccessTest()
+        public async Task PersistSuccessTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersist(con, () => new SigningRequest());
+            await TestUtil.TestPersist(con, () => new SigningRequest());
         }
 
         [Test]
-        public void PersistFailTest()
+        public async Task PersistFailTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersistFail(con, () => new SigningRequest());
+            await TestUtil.TestPersistFail(con, () => new SigningRequest());
         }
 
         [Test]
-        public void DeleteTest()
+        public async Task DeleteTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestDelete(con, () => new SigningRequest());
+            await TestUtil.TestDelete(con, () => new SigningRequest());
         }
 
         [Test]
-        public void GetTest()
+        public async Task GetTest()
         {
-            TestUtil.TestGet<SigningRequest>();
+            await TestUtil.TestGet<SigningRequest>();
         }
 
         [Test]
@@ -41,10 +42,10 @@ namespace PenneoTests
         }
 
         [Test]
-        public void SendTest()
+        public async Task SendTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPerformActionSuccess(con, () => new SigningRequest().SendAsync(con));
+            await TestUtil.TestPerformActionSuccess(con, () => new SigningRequest().SendAsync(con));
         }
 
         [Test]

--- a/Src/PenneoTests/TestUtil.cs
+++ b/Src/PenneoTests/TestUtil.cs
@@ -33,12 +33,12 @@ namespace PenneoTests
             return new ApiConnector(null, null, null, null, null, null, null, AuthType.WSSE);
         }
 
-        public static void TestPersist(PenneoConnector con, Func<Entity> f)
+        public static async Task TestPersist(PenneoConnector con, Func<Entity> f)
         {
             A.CallTo(() => con.ApiConnector.WriteObjectAsync(null)).WithAnyArguments();
 
             var e = f();
-            e.PersistAsync(con); 
+            await e.PersistAsync(con); 
 
             A.CallTo(() => con.ApiConnector.WriteObjectAsync(e)).MustHaveHappened();
         }
@@ -54,11 +54,11 @@ namespace PenneoTests
             Assert.IsFalse(result);
         }
 
-        public static void TestDelete(PenneoConnector con, Func<Entity> f)
+        public static async Task TestDelete(PenneoConnector con, Func<Entity> f)
         {
             var e = f();
             A.CallTo(() => con.ApiConnector.DeleteObjectAsync(e)).Returns(true);
-            e.DeleteAsync(con);
+            await e.DeleteAsync(con);
             A.CallTo(() => con.ApiConnector.DeleteObjectAsync(e)).MustHaveHappened();
         }   
 
@@ -73,8 +73,7 @@ namespace PenneoTests
             }
             A.CallTo(() => con.ApiConnector.FindByAsync<T>(null, null, null)).WithAnyArguments()
                 .Returns(Task.FromResult(
-                    new FindByResult<T> { Success = true, Objects = new List<T>(), Response = _response200 }))
-                .AssignsOutAndRefParameters(list, _response200);
+                    new FindByResult<T> { Success = true, Objects = list, Response = _response200 }));
 
             var q = new Query(con);
             var result = (await q.FindAllAsync<T>()).ToList();
@@ -137,11 +136,11 @@ namespace PenneoTests
         }
 
 
-        public static void TestPerformActionSuccess(PenneoConnector con, Action action)
+        public static async Task TestPerformActionSuccess(PenneoConnector con, Func<Task>func)
         {
             A.CallTo(() => con.ApiConnector.PerformAction(null, null)).WithAnyArguments().Returns(new ServerResult());
 
-            action();
+            await func();
 
             A.CallTo(() => con.ApiConnector.PerformAction(null, null)).WithAnyArguments().MustHaveHappened();
         }

--- a/Src/PenneoTests/ValidationTests.cs
+++ b/Src/PenneoTests/ValidationTests.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Threading.Tasks;
 using FakeItEasy;
 using NUnit.Framework;
 using Penneo;
@@ -17,30 +18,30 @@ namespace PenneoTests
         }
 
         [Test]
-        public void PersistSuccessTest()
+        public async Task PersistSuccessTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersist(con, () => new Validation());
+            await TestUtil.TestPersist(con, () => new Validation());
         }
 
         [Test]
-        public void PersistFailTest()
+        public async Task PersistFailTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPersistFail(con, () => new Validation());
+            await TestUtil.TestPersistFail(con, () => new Validation());
         }
 
         [Test]
-        public void DeleteTest()
+        public async Task DeleteTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestDelete(con, () => new Validation());
+            await TestUtil.TestDelete(con, () => new Validation());
         }
 
         [Test]
-        public void GetTest()
+        public async Task GetTest()
         {
-            TestUtil.TestGet<Validation>();
+            await TestUtil.TestGet<Validation>();
         }
 
         [Test]
@@ -58,7 +59,7 @@ namespace PenneoTests
         }
 
         [Test]
-        public void SavePdfTest()
+        public async Task SavePdfTest()
         {
             var con = TestUtil.CreatePenneoConnector();
             var data = new byte[] { 1, 2, 3 };
@@ -68,7 +69,7 @@ namespace PenneoTests
             var savePath = Path.GetTempFileName();
             try
             {
-                doc.SavePdfAsync(con, savePath);
+                await doc.SavePdfAsync(con, savePath);
                 var readBytes = File.ReadAllBytes(savePath);
                 CollectionAssert.AreEqual(data, readBytes);
             }
@@ -81,10 +82,10 @@ namespace PenneoTests
         }
 
         [Test]
-        public void SendTest()
+        public async Task SendTest()
         {
             var con = TestUtil.CreatePenneoConnector();
-            TestUtil.TestPerformActionSuccess(con, () => new Validation().SendAsync(con));
+            await TestUtil.TestPerformActionSuccess(con, () => new Validation().SendAsync(con));
         }
     }
 }


### PR DESCRIPTION
I noticed some of the unit tests were not awaiting asynchronous calls. That causes that some tests give false positives.

Once I changed the codes to await the calls, some tests started to fail. The reason is because the mock for `IApiConnector` were configured to expect `out` parameters:

```
            A.CallTo(() => con.ApiConnector.FindByAsync<T>(null, null, null)).WithAnyArguments()
                .Returns(Task.FromResult(
                    new FindByResult<T> { Success = true, Objects = new List<T>(), Response = _response200 }))
                .AssignsOutAndRefParameters(list, _response200); -----> Here is the error
```
As the `FindByResult` method doesn't have any `out` nor `ref` parameters, it caused an exception (the error was never identified by the tests because we were not awaiting the calls).

This fix basically makes the tests to await the calls when needed. 

I also cleaned a bit the codes to remove unused usings.

