### PR TITLE
Using configure await false

### DIFF
--- a/Src/Penneo/(Model)/CaseFile.cs
+++ b/Src/Penneo/(Model)/CaseFile.cs
@@ -174,7 +174,7 @@ namespace Penneo
         {
             if (_documents == null)
             {
-                _documents = (await GetLinkedEntitiesAsync<Document>(con)).Objects.ToList();
+                _documents = (await GetLinkedEntitiesAsync<Document>(con).ConfigureAwait(false)).Objects.ToList();
                 foreach (var doc in _documents)
                 {
                     doc.CaseFile = this;
@@ -213,7 +213,7 @@ namespace Penneo
         {
             if (Signers == null)
             {
-                Signers = (await GetLinkedEntitiesAsync<Signer>(con)).Objects.ToList();
+                Signers = (await GetLinkedEntitiesAsync<Signer>(con).ConfigureAwait(false)).Objects.ToList();
             }
             return Signers;
         }
@@ -230,7 +230,7 @@ namespace Penneo
             }
             if (signer == null)
             {
-                signer = await FindLinkedEntityAsync<Signer>(con, id);
+                signer = await FindLinkedEntityAsync<Signer>(con, id).ConfigureAwait(false);
             }
             if (signer != null)
             {
@@ -247,7 +247,7 @@ namespace Penneo
         {
             if (_copyRecipients == null)
             {
-                _copyRecipients = (await GetLinkedEntitiesAsync<CopyRecipient>(con)).Objects.ToList();
+                _copyRecipients = (await GetLinkedEntitiesAsync<CopyRecipient>(con).ConfigureAwait(false)).Objects.ToList();
                 foreach (var doc in _copyRecipients)
                 {
                     doc.CaseFile = this;
@@ -282,9 +282,9 @@ namespace Penneo
         /// <summary>
         /// Get all available case file templates
         /// </summary>
-        public async Task<QueryResult<CaseFileTemplate>> GetTemplatesAsync(PenneoConnector con)
+        public Task<QueryResult<CaseFileTemplate>> GetTemplatesAsync(PenneoConnector con)
         {
-            return await GetLinkedEntitiesAsync<CaseFileTemplate>(con, "casefile/casefiletypes");
+            return GetLinkedEntitiesAsync<CaseFileTemplate>(con, "casefile/casefiletypes");
         }
 
         /// <summary>
@@ -292,7 +292,7 @@ namespace Penneo
         /// </summary>
         public async Task<IEnumerable<DocumentType>> GetDocumentTypesAsync(PenneoConnector con)
         {
-            return (await GetLinkedEntitiesAsync<DocumentType>(con, "casefiles/" + Id + "/documenttypes")).Objects;
+            return (await GetLinkedEntitiesAsync<DocumentType>(con, "casefiles/" + Id + "/documenttypes").ConfigureAwait(false)).Objects;
         }
 
         /// <summary>
@@ -304,7 +304,7 @@ namespace Penneo
             {
                 return new List<SignerType>();
             }
-            return (await GetLinkedEntitiesAsync<SignerType>(con, "casefiles/" + Id + "/signertypes")).Objects;
+            return (await GetLinkedEntitiesAsync<SignerType>(con, "casefiles/" + Id + "/signertypes").ConfigureAwait(false)).Objects;
         }
 
         /// <summary>
@@ -316,7 +316,7 @@ namespace Penneo
             {
                 return null;
             }
-            var r = await GetLinkedEntityAsync<User>(con, "customers/" + CustomerId + "/users/" + UserId);
+            var r = await GetLinkedEntityAsync<User>(con, "customers/" + CustomerId + "/users/" + UserId).ConfigureAwait(false);
             return r != null ? r.Object : null;
         }
 
@@ -329,8 +329,8 @@ namespace Penneo
             {
                 return null;
             }
-            var r = await GetLinkedEntityAsync<Customer>(con, "customers/" + CustomerId);
-            return r != null ? r.Object : null;
+            var r = await GetLinkedEntityAsync<Customer>(con, "customers/" + CustomerId).ConfigureAwait(false);
+            return r?.Object;
         }
 
         /// <summary>
@@ -340,7 +340,7 @@ namespace Penneo
         {
             if (Id.HasValue && CaseFileTemplate == null)
             {
-                var caseFileTypes = await GetLinkedEntitiesAsync<CaseFileTemplate>(con);
+                var caseFileTypes = await GetLinkedEntitiesAsync<CaseFileTemplate>(con).ConfigureAwait(false);
                 CaseFileTemplate = caseFileTypes.Objects.FirstOrDefault();
             }
             return CaseFileTemplate;
@@ -357,9 +357,9 @@ namespace Penneo
         /// <summary>
         /// Get all errors associated with the case file
         /// </summary>
-        public async Task<IEnumerable<string>> GetErrorsAsync(PenneoConnector con)
+        public Task<IEnumerable<string>> GetErrorsAsync(PenneoConnector con)
         {
-            return await GetStringListAssetAsync(con, "errors");
+            return GetStringListAssetAsync(con, "errors");
         }
 
         /// <summary>
@@ -367,7 +367,7 @@ namespace Penneo
         /// </summary>
         public async Task<bool> SendAsync(PenneoConnector con)
         {
-            return (await PerformActionAsync(con, ACTION_SEND)).Success;
+            return (await PerformActionAsync(con, ACTION_SEND).ConfigureAwait(false)).Success;
         }
 
         /// <summary>
@@ -375,7 +375,7 @@ namespace Penneo
         /// </summary>
         public async Task<bool> ActivateAsync(PenneoConnector con)
         {
-            return (await PerformActionAsync(con, ACTION_ACTIVATE)).Success;
+            return (await PerformActionAsync(con, ACTION_ACTIVATE).ConfigureAwait(false)).Success;
         }
     }
 }

--- a/Src/Penneo/(Model)/CaseFile.cs
+++ b/Src/Penneo/(Model)/CaseFile.cs
@@ -317,7 +317,7 @@ namespace Penneo
                 return null;
             }
             var r = await GetLinkedEntityAsync<User>(con, "customers/" + CustomerId + "/users/" + UserId).ConfigureAwait(false);
-            return r != null ? r.Object : null;
+            return r?.Object;
         }
 
         /// <summary>

--- a/Src/Penneo/(Model)/Document.cs
+++ b/Src/Penneo/(Model)/Document.cs
@@ -120,10 +120,10 @@ namespace Penneo
         {
             if (Id.HasValue && DocumentType == null)
             {
-                var documentTypes = await GetLinkedEntitiesAsync<DocumentType>(con);
+                var documentTypes = await GetLinkedEntitiesAsync<DocumentType>(con).ConfigureAwait(false);
                 DocumentType = documentTypes.Objects.FirstOrDefault();
             }
-            return await Task.FromResult(DocumentType);
+            return DocumentType;
         }
 
 
@@ -189,7 +189,7 @@ namespace Penneo
         {
             if (CaseFile == null)
             {
-                CaseFile = (await GetLinkedEntitiesAsync<CaseFile>(con)).Objects.FirstOrDefault();
+                CaseFile = (await GetLinkedEntitiesAsync<CaseFile>(con).ConfigureAwait(false)).Objects.FirstOrDefault();
             }
             return CaseFile;
         }
@@ -222,7 +222,7 @@ namespace Penneo
         {
             if (PdfRaw == null)
             {
-                PdfRaw = await GetFileAssetsAsync(con, ASSET_PDF);
+                PdfRaw = await GetFileAssetsAsync(con, ASSET_PDF).ConfigureAwait(false);
             }
             return PdfRaw;
         }
@@ -240,7 +240,7 @@ namespace Penneo
         /// </summary>
         public async Task SavePdfAsync(PenneoConnector con, string path)
         {
-            var data = await GetPdfAsync(con);
+            var data = await GetPdfAsync(con).ConfigureAwait(false);
             if (File.Exists(path))
             {
                 File.Delete(path);
@@ -265,7 +265,7 @@ namespace Penneo
         {
             if (_signatureLines == null)
             {
-                _signatureLines = (await GetLinkedEntitiesAsync<SignatureLine>(con)).Objects.ToList();
+                _signatureLines = (await GetLinkedEntitiesAsync<SignatureLine>(con).ConfigureAwait(false)).Objects.ToList();
             }
             foreach (var sl in _signatureLines)
             {
@@ -286,7 +286,7 @@ namespace Penneo
             {
                 return _signatureLines.FirstOrDefault(x => x.Id == id);
             }
-            var sl = await FindLinkedEntityAsync<SignatureLine>(con, id);
+            var sl = await FindLinkedEntityAsync<SignatureLine>(con, id).ConfigureAwait(false);
             sl.Document = this;
             return sl;
         }

--- a/Src/Penneo/(Model)/Entity.cs
+++ b/Src/Penneo/(Model)/Entity.cs
@@ -74,7 +74,7 @@ namespace Penneo
         public async Task<bool> PersistAsync(PenneoConnector con)
         {
             con.Log((IsNew ? "Creating" : "Updating") + " " + GetType().Name + " (" + (Id.HasValue ? Id.ToString() : "new") + ")", LogSeverity.Information);
-            var success = await con.ApiConnector.WriteObjectAsync(this);
+            var success = await con.ApiConnector.WriteObjectAsync(this).ConfigureAwait(false);
             if (!success)
             {
                 con.Log((IsNew ? "Creating" : "Updating") + " " + GetType().Name + " (" + (Id.HasValue ? Id.ToString() : "new") + ") failed", LogSeverity.Information);
@@ -88,7 +88,7 @@ namespace Penneo
         public async Task DeleteAsync(PenneoConnector con)
         {
             con.Log("Deleting " + GetType().Name + " (" + (Id.HasValue ? Id.ToString() : "new") + ")", LogSeverity.Information);
-            if (!await con.ApiConnector.DeleteObjectAsync(this))
+            if (!await con.ApiConnector.DeleteObjectAsync(this).ConfigureAwait(false))
             {
                 throw new Exception("Penneo: Could not delete the " + GetType().Name);
             }
@@ -106,96 +106,96 @@ namespace Penneo
         /// <summary>
         /// Link this entity with the given child in the storage
         /// </summary>
-        protected async Task<bool> LinkEntityAsync(PenneoConnector con, Entity child)
+        protected Task<bool> LinkEntityAsync(PenneoConnector con, Entity child)
         {
             con.Log("Linking " +
                     GetType().Name + " (" + (Id.HasValue ? Id.ToString() : "new") + ") TO " +
                     child.GetType().Name + " (" + (child.Id.HasValue ? Id.ToString() : "new") + ")", LogSeverity.Information);
-            return await con.ApiConnector.LinkEntityAsync(this, child);
+            return con.ApiConnector.LinkEntityAsync(this, child);
         }
 
         /// <summary>
         /// Unlink this entity with the given child in the storage
         /// </summary>
-        protected async Task<bool> UnlinkEntity(PenneoConnector con, Entity child)
+        protected Task<bool> UnlinkEntity(PenneoConnector con, Entity child)
         {
             con.Log("Unlinking " +
                     GetType().Name + " (" + (Id.HasValue ? Id.ToString() : "new") + ") TO " +
                     child.GetType().Name + " (" + (child.Id.HasValue ? Id.ToString() : "new") + ")", LogSeverity.Information);
-            return await con.ApiConnector.UnlinkEntityAsync(this, child);
+            return con.ApiConnector.UnlinkEntityAsync(this, child);
         }
 
         /// <summary>
         /// Get all entities linked with this entity in the storage
         /// </summary>
-        protected async Task<QueryResult<T>> GetLinkedEntitiesAsync<T>(PenneoConnector con, string url = null)
+        protected Task<QueryResult<T>> GetLinkedEntitiesAsync<T>(PenneoConnector con, string url = null)
             where T: Entity
         {
-            return await con.ApiConnector.GetLinkedEntitiesAsync<T>(this, url);
+            return con.ApiConnector.GetLinkedEntitiesAsync<T>(this, url);
         }
 
         /// <summary>
         /// Get entity linked with this entity based on url
         /// </summary>
-        protected async Task<QuerySingleObjectResult<T>> GetLinkedEntityAsync<T>(PenneoConnector con, string url = null)
+        protected Task<QuerySingleObjectResult<T>> GetLinkedEntityAsync<T>(PenneoConnector con, string url = null)
             where T: Entity
         {
-            return await con.ApiConnector.GetLinkedEntityAsync<T>(this, url);
+            return con.ApiConnector.GetLinkedEntityAsync<T>(this, url);
         }
 
         /// <summary>
         /// Find a specific linked entity
         /// </summary>
-        protected async Task<T> FindLinkedEntityAsync<T>(PenneoConnector con, int id)
+        protected Task<T> FindLinkedEntityAsync<T>(PenneoConnector con, int id)
         {
-            return await con.ApiConnector.FindLinkedEntityAsync<T>(this, id);
+            return con.ApiConnector.FindLinkedEntityAsync<T>(this, id);
         }
 
         /// <summary>
         /// Get file assets with the given name for this entity
         /// </summary>
-        protected async Task<byte[]> GetFileAssetsAsync(PenneoConnector con, string assetName)
+        protected Task<byte[]> GetFileAssetsAsync(PenneoConnector con, string assetName)
         {
-            return await con.ApiConnector.GetFileAssetsAsync(this, assetName);
+            return con.ApiConnector.GetFileAssetsAsync(this, assetName);
         }
 
         /// <summary>
         /// Get text assets with the given name for this entity
         /// </summary>
-        protected async Task<string> GetTextAssetsAsync(PenneoConnector con, string assetName)
+        protected Task<string> GetTextAssetsAsync(PenneoConnector con, string assetName)
         {
-            return await con.ApiConnector.GetTextAssetsAsync(this, assetName);
+            return con.ApiConnector.GetTextAssetsAsync(this, assetName);
         }
 
-        protected async Task<T> GetAssetAsync<T>(PenneoConnector con, string assetName)
+        protected Task<T> GetAssetAsync<T>(PenneoConnector con, string assetName)
         {
-            return await con.ApiConnector.GetAssetAsync<T>(this, assetName);
+            return con.ApiConnector.GetAssetAsync<T>(this, assetName);
         }
 
         /// <summary>
         /// Get list of string asset with the given name for this entity
         /// </summary>
-        protected async Task<IEnumerable<string>> GetStringListAssetAsync(PenneoConnector con, string assetName)
+        protected Task<IEnumerable<string>> GetStringListAssetAsync(PenneoConnector con, string assetName)
         {
-            return await con.ApiConnector.GetStringListAssetAsync(this, assetName);
+            return con.ApiConnector.GetStringListAssetAsync(this, assetName);
         }
 
         /// <summary>
         /// Perform the given action on this entity
         /// </summary>
-        protected async Task<ServerResult> PerformActionAsync(PenneoConnector con, string action)
+        protected Task<ServerResult> PerformActionAsync(PenneoConnector con, string action)
         {
-            return await con.ApiConnector.PerformAction(this, action);
+            return con.ApiConnector.PerformAction(this, action);
         }
 
-        protected async Task<ServerResult> PerformComplexActionAsync(
+        protected Task<ServerResult> PerformComplexActionAsync(
             PenneoConnector con,
             Method method,
             string action,
             Dictionary<string, object> data
         )
         {
-            return await con.ApiConnector.PerformComplexActionAsync(this, method, action, data);
+            return con.ApiConnector.PerformComplexActionAsync(this, method, action, data);
         }
 
         /// <summary>

--- a/Src/Penneo/(Model)/Folder.cs
+++ b/Src/Penneo/(Model)/Folder.cs
@@ -67,17 +67,17 @@ namespace Penneo
             {
                 return new List<CaseFile>();
             }
-            return (await GetLinkedEntitiesAsync<CaseFile>(con, "folders/" + Id + "/casefiles")).Objects;
+            return (await GetLinkedEntitiesAsync<CaseFile>(con, "folders/" + Id + "/casefiles").ConfigureAwait(false)).Objects;
         }
 
-        public async Task<bool> AddCaseFileAsync(PenneoConnector con, CaseFile caseFile)
+        public Task<bool> AddCaseFileAsync(PenneoConnector con, CaseFile caseFile)
         {
-            return await LinkEntityAsync(con, caseFile);
+            return LinkEntityAsync(con, caseFile);
         }
 
-        public async Task<bool> RemoveCaseFileAsync(PenneoConnector con, CaseFile caseFile)
+        public Task<bool> RemoveCaseFileAsync(PenneoConnector con, CaseFile caseFile)
         {
-            return await UnlinkEntity(con, caseFile);
+            return UnlinkEntity(con, caseFile);
         }
 
         public async Task<IEnumerable<Validation>> GetValidationsAsync(PenneoConnector con)
@@ -86,17 +86,17 @@ namespace Penneo
             {
                 return new List<Validation>();
             }
-            return (await GetLinkedEntitiesAsync<Validation>(con, "folders/" + Id + "/validations")).Objects;
+            return (await GetLinkedEntitiesAsync<Validation>(con, "folders/" + Id + "/validations").ConfigureAwait(false)).Objects;
         }
 
-        public async Task<bool> AddValidationAsync(PenneoConnector con, Validation validation)
+        public Task<bool> AddValidationAsync(PenneoConnector con, Validation validation)
         {
-            return await LinkEntityAsync(con, validation);
+            return LinkEntityAsync(con, validation);
         }
 
-        public async Task<bool> RemoveValidationAsync(PenneoConnector con, Validation validation)
+        public Task<bool> RemoveValidationAsync(PenneoConnector con, Validation validation)
         {
-            return await UnlinkEntity(con, validation);
+            return UnlinkEntity(con, validation);
         }
 
         public override string ToString()

--- a/Src/Penneo/(Model)/SignatureLine.cs
+++ b/Src/Penneo/(Model)/SignatureLine.cs
@@ -108,11 +108,11 @@ namespace Penneo
             {
                 if (SignerId.HasValue)
                 {
-                    Signer = await Document.CaseFile.FindSignerAsync(con, SignerId.Value);
+                    Signer = await Document.CaseFile.FindSignerAsync(con, SignerId.Value).ConfigureAwait(false);
                 }
                 else
                 {
-                    Signer = (await GetLinkedEntitiesAsync<Signer>(con)).Objects.FirstOrDefault();
+                    Signer = (await GetLinkedEntitiesAsync<Signer>(con).ConfigureAwait(false)).Objects.FirstOrDefault();
                     if (Signer != null)
                     {
                         Signer.CaseFile = Document.CaseFile;
@@ -123,10 +123,10 @@ namespace Penneo
             return Signer;
         }
 
-        public async Task<bool> SetSignerAsync(PenneoConnector con, Signer signer)
+        public Task<bool> SetSignerAsync(PenneoConnector con, Signer signer)
         {
             Signer = signer;
-            return await LinkEntityAsync(con, Signer);
+            return LinkEntityAsync(con, Signer);
         }
     }
 }

--- a/Src/Penneo/(Model)/Signer.cs
+++ b/Src/Penneo/(Model)/Signer.cs
@@ -58,7 +58,7 @@ namespace Penneo
         {
             if (SigningRequest == null)
             {
-                SigningRequest = (await GetLinkedEntitiesAsync<SigningRequest>(con)).Objects.FirstOrDefault();
+                SigningRequest = (await GetLinkedEntitiesAsync<SigningRequest>(con).ConfigureAwait(false)).Objects.FirstOrDefault();
             }
             return SigningRequest;
         }
@@ -70,24 +70,24 @@ namespace Penneo
         /// <param name="con"></param>
         /// <param name="type"></param>
         /// <returns></returns>
-        public async Task<bool> AddSignerType(PenneoConnector con, SignerType type)
+        public Task<bool> AddSignerType(PenneoConnector con, SignerType type)
         {
-            return await LinkEntityAsync(con, type);
+            return LinkEntityAsync(con, type);
         }
 
-        public async Task<bool> RemoveSignerType(PenneoConnector con, SignerType type)
+        public Task<bool> RemoveSignerType(PenneoConnector con, SignerType type)
         {
-            return await UnlinkEntity(con, type);
+            return UnlinkEntity(con, type);
         }
 
         public async Task<IEnumerable<SignerType>> GetSignerTypes(PenneoConnector con)
         {
-            return (await GetLinkedEntitiesAsync<SignerType>(con)).Objects;
+            return (await GetLinkedEntitiesAsync<SignerType>(con).ConfigureAwait(false)).Objects;
         }
 
         public async Task<IEnumerable<LogEntry>> GetEventLog(PenneoConnector con)
         {
-            return (await GetLinkedEntitiesAsync<LogEntry>(con)).Objects;
+            return (await GetLinkedEntitiesAsync<LogEntry>(con).ConfigureAwait(false)).Objects;
         }
     }
 }

--- a/Src/Penneo/(Model)/SigningRequest.cs
+++ b/Src/Penneo/(Model)/SigningRequest.cs
@@ -37,9 +37,9 @@ namespace Penneo
         /// <summary>
         /// Get the signing request link
         /// </summary>
-        public async Task<string> GetLinkAsync(PenneoConnector con)
+        public Task<string> GetLinkAsync(PenneoConnector con)
         {
-            return await GetTextAssetsAsync(con, ASSET_LINK);
+            return GetTextAssetsAsync(con, ASSET_LINK);
         }
 
         /// <summary>
@@ -47,7 +47,7 @@ namespace Penneo
         /// </summary>
         public async Task<bool> SendAsync(PenneoConnector con)
         {
-            return (await PerformActionAsync(con, ACTION_SEND)).Success;
+            return (await PerformActionAsync(con, ACTION_SEND).ConfigureAwait(false)).Success;
         }
     }
 

--- a/Src/Penneo/(Model)/User.cs
+++ b/Src/Penneo/(Model)/User.cs
@@ -19,7 +19,7 @@ namespace Penneo
 
         public async Task<IEnumerable<Customer>> GetCustomers(PenneoConnector con)
         {
-            return _customers ?? (_customers = (await GetLinkedEntitiesAsync<Customer>(con)).Objects.ToList());
+            return _customers ?? (_customers = (await GetLinkedEntitiesAsync<Customer>(con).ConfigureAwait(false)).Objects.ToList());
         }
     }
 }

--- a/Src/Penneo/(Model)/Validation.cs
+++ b/Src/Penneo/(Model)/Validation.cs
@@ -45,14 +45,14 @@ namespace Penneo
             return (ValidationStatus) Status;
         }
 
-        public async Task<byte[]> GetPdfAsync(PenneoConnector con)
+        public Task<byte[]> GetPdfAsync(PenneoConnector con)
         {
-            return await GetFileAssetsAsync(con, ASSET_PDF);
+            return GetFileAssetsAsync(con, ASSET_PDF);
         }
 
         public async Task SavePdfAsync(PenneoConnector con, string path)
         {
-            var data = await GetPdfAsync(con);
+            var data = await GetPdfAsync(con).ConfigureAwait(false);
             if (File.Exists(path))
             {
                 File.Delete(path);
@@ -60,24 +60,24 @@ namespace Penneo
             File.WriteAllBytes(path, data);
         }
 
-        public async Task<string> GetLinkAsync(PenneoConnector con)
+        public Task<string> GetLinkAsync(PenneoConnector con)
         {
-            return await GetTextAssetsAsync(con, ASSET_LINK);
+            return GetTextAssetsAsync(con, ASSET_LINK);
         }
 
-        public async Task<ValidationContents> GetContents(PenneoConnector con)
+        public Task<ValidationContents> GetContents(PenneoConnector con)
         {
-            return await GetAssetAsync<ValidationContents>(con, ASSET_CONTENTS);
+            return GetAssetAsync<ValidationContents>(con, ASSET_CONTENTS);
         }
 
         public async Task<bool> SendAsync(PenneoConnector con)
         {
-            return (await PerformActionAsync(con, ACTION_SEND)).Success;
+            return (await PerformActionAsync(con, ACTION_SEND).ConfigureAwait(false)).Success;
         }
 
         public async Task<IEnumerable<LogEntry>> GetEventLog(PenneoConnector con)
         {
-            return (await GetLinkedEntitiesAsync<LogEntry>(con)).Objects;
+            return (await GetLinkedEntitiesAsync<LogEntry>(con).ConfigureAwait(false)).Objects;
         }
     }
 

--- a/Src/Penneo/(Model)/WebhookSubscription.cs
+++ b/Src/Penneo/(Model)/WebhookSubscription.cs
@@ -29,7 +29,7 @@ namespace Penneo
         public async Task<bool> ConfirmAsync(PenneoConnector con, string token)
         {
             var data = new Dictionary<string, object> {{"token", token}};
-            return (await PerformComplexActionAsync(con, Method.Post, "confirm", data)).Success;
+            return (await PerformComplexActionAsync(con, Method.Post, "confirm", data).ConfigureAwait(false)).Success;
         }
     }
 }

--- a/Src/Penneo/(Query)/Query.cs
+++ b/Src/Penneo/(Query)/Query.cs
@@ -245,7 +245,7 @@ namespace Penneo
             _con.Log("GetNextPageAsync (" + typeof(T).Name + ")", LogSeverity.Information);
             if (!result.NextPage.HasValue)
             {
-                return null;
+                return Task.FromResult<QueryResult<T>>(null);
             }
             return GetPageAsync(result, result.NextPage);
         }
@@ -259,7 +259,7 @@ namespace Penneo
             _con.Log("GetPreviousPageAsync (" + typeof(T).Name + ")", LogSeverity.Information);
             if (!result.PrevPage.HasValue)
             {
-                return null;
+                return Task.FromResult<QueryResult<T>>(null);
             }
             return GetPageAsync(result, result.PrevPage);
         }
@@ -273,7 +273,7 @@ namespace Penneo
             _con.Log("GetFirstPageAsync (" + typeof(T).Name + ")", LogSeverity.Information);
             if (!result.FirstPage.HasValue)
             {
-                return null;
+                return Task.FromResult<QueryResult<T>>(null);
             }
             return GetPageAsync(result, result.FirstPage);
         }

--- a/Src/Penneo/(Query)/Query.cs
+++ b/Src/Penneo/(Query)/Query.cs
@@ -158,7 +158,7 @@ namespace Penneo
                         findByResult.Response.Headers.FirstOrDefault(x => x.Name.Equals("link", StringComparison.OrdinalIgnoreCase));
                     if (linkHeader != null && linkHeader.Value != null)
                     {
-                        PaginationUtil.ParseRepsonseHeadersForPagination(linkHeader.Value.ToString(), output);
+                        PaginationUtil.ParseResponseHeadersForPagination(linkHeader.Value.ToString(), output);
                     }
                 }
 

--- a/Src/Penneo/(Query)/Query.cs
+++ b/Src/Penneo/(Query)/Query.cs
@@ -27,7 +27,7 @@ namespace Penneo
         public async Task<T> FindAsync<T>(int id)
             where T : Entity
         {
-            var output = await FindByIdAsync<T>(id);
+            var output = await FindByIdAsync<T>(id).ConfigureAwait(false);
             if (!output.Success)
             {
                 throw new Exception(output.ErrorMessage);
@@ -39,7 +39,7 @@ namespace Penneo
             where T : Entity
         {
             RestResponse response;
-            var objectResult = await _con.ApiConnector.ReadObjectAsync<T>(null, id);
+            var objectResult = await _con.ApiConnector.ReadObjectAsync<T>(null, id).ConfigureAwait(false);
             return CreateSingleObjectResult(objectResult.Response, objectResult.Result, id);
         }
 
@@ -50,14 +50,14 @@ namespace Penneo
             where T : Entity
         {
             var input = new QueryInput { Criteria = criteria, OrderBy = orderBy };
-            return (await FindOneByAsync<T>(input)).Object;
+            return (await FindOneByAsync<T>(input).ConfigureAwait(false)).Object;
         }
 
         public async Task<QuerySingleObjectResult<T>> FindOneByAsync<T>(QueryInput input)
             where T : Entity
         {
             _con.Log("FindOneByAsync (" + typeof(T).Name + ")", LogSeverity.Information);
-            var result = new QuerySingleObjectResult<T>(await FindByAsync<T>(input));
+            var result = new QuerySingleObjectResult<T>(await FindByAsync<T>(input).ConfigureAwait(false));
             return result;
         }
 
@@ -69,7 +69,7 @@ namespace Penneo
         {
             _con.Log("FindAllAsync (" + typeof(T).Name + ")", LogSeverity.Information);
             var input = new QueryInput();
-            return (await FindByAsync<T>(input)).Objects;
+            return (await FindByAsync<T>(input).ConfigureAwait(false)).Objects;
         }
 
         /// <summary>
@@ -84,7 +84,7 @@ namespace Penneo
             input.PerPage = perPage;
             input.Page = page;
             
-            var output = await FindByAsync<T>(input);
+            var output = await FindByAsync<T>(input).ConfigureAwait(false);
             if (!output.Success)
             {
                 if (!string.IsNullOrEmpty(output.ErrorMessage))
@@ -133,7 +133,7 @@ namespace Penneo
             var output = new QueryResult<T>();
             output.Input = input;
             
-            var findByResult = await _con.ApiConnector.FindByAsync<T>(query, input.Page, input.PerPage);
+            var findByResult = await _con.ApiConnector.FindByAsync<T>(query, input.Page, input.PerPage).ConfigureAwait(false);
 
             output.Success = findByResult.Success;
             output.Objects = findByResult.Objects;
@@ -199,7 +199,7 @@ namespace Penneo
             {
                 resource += $"&language={isoLanguage}";
             }
-            var result = await _con.ApiConnector.CallServerAsync(resource);
+            var result = await _con.ApiConnector.CallServerAsync(resource).ConfigureAwait(false);
             var obj = JsonConvert.DeserializeObject<MessageTemplate>(result.Content);
             obj.Title = "Standard";
             return new QueryResult<MessageTemplate>() { Objects = new[] { obj }, Success = true };
@@ -211,7 +211,7 @@ namespace Penneo
         public async Task<QuerySingleObjectResult<User>> GetUserAsync()
         {
             RestResponse response;
-            var objectResult = await _con.ApiConnector.ReadObjectAsync<User>(null, null, "user");
+            var objectResult = await _con.ApiConnector.ReadObjectAsync<User>(null, null, "user").ConfigureAwait(false);
             return CreateSingleObjectResult(objectResult.Response, objectResult.Result, null);
         }
 
@@ -239,7 +239,7 @@ namespace Penneo
         /// <summary>
         /// Get the next page based on an earlier result
         /// </summary>
-        public async Task<QueryResult<T>> GetNextPageAsync<T>(QueryResult<T> result)
+        public Task<QueryResult<T>> GetNextPageAsync<T>(QueryResult<T> result)
             where T : Entity
         {
             _con.Log("GetNextPageAsync (" + typeof(T).Name + ")", LogSeverity.Information);
@@ -247,13 +247,13 @@ namespace Penneo
             {
                 return null;
             }
-            return await GetPageAsync(result, result.NextPage);
+            return GetPageAsync(result, result.NextPage);
         }
 
         /// <summary>
         /// Get the previous page based on an earlier result
         /// </summary>
-        public async Task<QueryResult<T>> GetPreviousPageAsync<T>(QueryResult<T> result)
+        public Task<QueryResult<T>> GetPreviousPageAsync<T>(QueryResult<T> result)
             where T : Entity
         {
             _con.Log("GetPreviousPageAsync (" + typeof(T).Name + ")", LogSeverity.Information);
@@ -261,13 +261,13 @@ namespace Penneo
             {
                 return null;
             }
-            return await GetPageAsync(result, result.PrevPage);
+            return GetPageAsync(result, result.PrevPage);
         }
 
         /// <summary>
         /// Get the first page based on an earlier result
         /// </summary>
-        public async Task<QueryResult<T>> GetFirstPageAsync<T>(QueryResult<T> result)
+        public Task<QueryResult<T>> GetFirstPageAsync<T>(QueryResult<T> result)
             where T : Entity
         {
             _con.Log("GetFirstPageAsync (" + typeof(T).Name + ")", LogSeverity.Information);
@@ -275,20 +275,20 @@ namespace Penneo
             {
                 return null;
             }
-            return await GetPageAsync(result, result.FirstPage);
+            return GetPageAsync(result, result.FirstPage);
         }
 
         /// <summary>
         /// Get the first page of a given entity
         /// </summary>
-        public async Task<QueryResult<T>> GetFirstPageAsync<T>(int? perPage = null)
+        public Task<QueryResult<T>> GetFirstPageAsync<T>(int? perPage = null)
             where T : Entity
         {
             _con.Log("GetFirstPageAsync (" + typeof(T).Name + ")", LogSeverity.Information);
             var input = new QueryInput();
             input.Page = 1;
             input.PerPage = perPage;
-            return await FindByAsync<T>(input);
+            return FindByAsync<T>(input);
         }
 
         private void ThrowIfNoPagination<T>(QueryResult<T> result, int? page)
@@ -300,13 +300,13 @@ namespace Penneo
             }
         }
 
-        private async Task<QueryResult<T>> GetPageAsync<T>(QueryResult<T> result, int? page)
+        private Task<QueryResult<T>> GetPageAsync<T>(QueryResult<T> result, int? page)
             where T : Entity
         {
             ThrowIfNoPagination(result, page);
             var pageInput = (QueryInput)result.Input.Clone();
             pageInput.Page = page;
-            return await FindByAsync<T>(pageInput);
+            return FindByAsync<T>(pageInput);
         }
     }
 }

--- a/Src/Penneo/Connector/ApiConnector.cs
+++ b/Src/Penneo/Connector/ApiConnector.cs
@@ -130,12 +130,12 @@ namespace Penneo.Connector
             }
             if (!obj.IsNew)
             {
-                var response = await CallServerAsync(obj.GetRelativeUrl(_con) + "/" + obj.Id, data, Method.Put);
+                var response = await CallServerAsync(obj.GetRelativeUrl(_con) + "/" + obj.Id, data, Method.Put).ConfigureAwait(false);
                 return ExtractResponse(obj, response, result);
             }
             else
             {
-                var response = await CallServerAsync(obj.GetRelativeUrl(_con), data, Method.Post);
+                var response = await CallServerAsync(obj.GetRelativeUrl(_con), data, Method.Post).ConfigureAwait(false);
                 var successful = ExtractResponse(obj, response, result);
                 if (successful)
                 {
@@ -175,13 +175,13 @@ namespace Penneo.Connector
         /// </summary>
         public async Task<bool> DeleteObjectAsync(Entity obj)
         {
-            var response = await CallServerAsync(obj.GetRelativeUrl(_con) + '/' + obj.Id, null, Method.Delete);
+            var response = await CallServerAsync(obj.GetRelativeUrl(_con) + '/' + obj.Id, null, Method.Delete).ConfigureAwait(false);
             return response != null && (response.StatusCode == HttpStatusCode.OK || response.StatusCode == HttpStatusCode.NoContent);
         }
 
-        public async Task<ReadObjectResult<T>> ReadObjectAsync<T>(Entity parent, int? id) where T : Entity
+        public Task<ReadObjectResult<T>> ReadObjectAsync<T>(Entity parent, int? id) where T : Entity
         {
-            return await ReadObjectAsync<T>(parent, id, null);
+            return ReadObjectAsync<T>(parent, id, null);
         }
 
         public async Task<ReadObjectResult<T>> ReadObjectAsync<T>(Entity parent, int? id, string relativeUrl) where T : Entity
@@ -191,7 +191,7 @@ namespace Penneo.Connector
             {
                 url += "/" + id;
             }
-            var response = await CallServerAsync(url);
+            var response = await CallServerAsync(url).ConfigureAwait(false);
             if (response == null || response.StatusCode != HttpStatusCode.OK)
             {
                 return new ReadObjectResult<T> { Response = response, Result = default };
@@ -211,7 +211,7 @@ namespace Penneo.Connector
         public async Task<bool> LinkEntityAsync(Entity parent, Entity child)
         {
             var url = parent.GetRelativeUrl(_con) + "/" + parent.Id + "/" + _restResources.GetResource(child.GetType()) + "/" + child.Id;
-            var response = await CallServerAsync(url, method: Method.Post);
+            var response = await CallServerAsync(url, method: Method.Post).ConfigureAwait(false);
             var result = new ServerResult();
             return ExtractResponse(parent, response, result);
         }
@@ -222,7 +222,7 @@ namespace Penneo.Connector
         public async Task<bool> UnlinkEntityAsync(Entity parent, Entity child)
         {
             var url = parent.GetRelativeUrl(_con) + "/" + parent.Id + "/" + _restResources.GetResource(child.GetType()) + "/" + child.Id;
-            var response = await CallServerAsync(url, method: Method.Delete);
+            var response = await CallServerAsync(url, method: Method.Delete).ConfigureAwait(false);
             var result = new ServerResult();
             return ExtractResponse(parent, response, result);
         }
@@ -243,7 +243,7 @@ namespace Penneo.Connector
                 actualUrl = url;
             }
 
-            var response = await CallServerAsync(actualUrl);
+            var response = await CallServerAsync(actualUrl).ConfigureAwait(false);
             var result = new QueryResult<T>();
             if (ExtractResponse(obj, response, result))
             {
@@ -268,7 +268,7 @@ namespace Penneo.Connector
                 actualUrl = url;
             }
 
-            var response = await CallServerAsync(actualUrl);
+            var response = await CallServerAsync(actualUrl).ConfigureAwait(false);
             var result = new QuerySingleObjectResult<T>();
             if (ExtractResponse(obj, response, result))
             {
@@ -283,7 +283,7 @@ namespace Penneo.Connector
         public async Task<T> FindLinkedEntityAsync<T>(Entity obj, int id)
         {
             var url = obj.GetRelativeUrl(_con) + "/" + obj.Id + "/" + _restResources.GetResource<T>() + "/" + id;
-            var response = await CallServerAsync(url);
+            var response = await CallServerAsync(url).ConfigureAwait(false);
             if (response == null || !_successStatusCodes.Contains(response.StatusCode))
             {
                 throw new Exception("Penneo: Internal problem encountered");
@@ -294,7 +294,7 @@ namespace Penneo.Connector
         public async Task<T> GetAssetAsync<T>(Entity obj, string assetName)
         {
             var url = obj.GetRelativeUrl(_con) + "/" + obj.Id + "/" + assetName;
-            var response = await CallServerAsync(url);
+            var response = await CallServerAsync(url).ConfigureAwait(false);
             if (response == null || string.IsNullOrEmpty(response.Content) || !_successStatusCodes.Contains(response.StatusCode))
             {
                 return default(T);
@@ -308,7 +308,7 @@ namespace Penneo.Connector
         /// </summary>
         public async Task<byte[]> GetFileAssetsAsync(Entity obj, string assetName)
         {
-            var encoded = await GetTextAssetsAsync(obj, assetName);
+            var encoded = await GetTextAssetsAsync(obj, assetName).ConfigureAwait(false);
             return Convert.FromBase64String(encoded);
         }
 
@@ -318,7 +318,7 @@ namespace Penneo.Connector
         public async Task<string> GetTextAssetsAsync(Entity obj, string assetName)
         {
             var url = obj.GetRelativeUrl(_con) + "/" + obj.Id + "/" + assetName;
-            var response = await CallServerAsync(url);
+            var response = await CallServerAsync(url).ConfigureAwait(false);
             var result = JsonConvert.DeserializeObject<string[]>(response.Content);
             return result[0];
         }
@@ -329,7 +329,7 @@ namespace Penneo.Connector
         public async Task<IEnumerable<string>> GetStringListAssetAsync(Entity obj, string assetName)
         {
             var url = obj.GetRelativeUrl(_con) + "/" + obj.Id + "/" + assetName;
-            var response = await CallServerAsync(url);
+            var response = await CallServerAsync(url).ConfigureAwait(false);
             var result = JsonConvert.DeserializeObject<string[]>(response.Content);
             return result;
         }
@@ -348,7 +348,7 @@ namespace Penneo.Connector
                 options = new Dictionary<string, Dictionary<string, object>>();
                 options["query"] = query;
             }
-            var response = await CallServerAsync(resource, null, Method.Get, options, page: page, perPage: perPage);
+            var response = await CallServerAsync(resource, null, Method.Get, options, page: page, perPage: perPage).ConfigureAwait(false);
             if (response == null || !_successStatusCodes.Contains(response.StatusCode))
             {
                 return new FindByResult<T> { Success = false };
@@ -373,7 +373,7 @@ namespace Penneo.Connector
         {
             var result = new ServerResult();
             var url = obj.GetRelativeUrl(_con) + "/" + obj.Id + "/" + action;
-            var response = await CallServerAsync(url, data, method);
+            var response = await CallServerAsync(url, data, method).ConfigureAwait(false);
             if (response == null || !_successStatusCodes.Contains(response.StatusCode))
             {
                 result.Success = false;
@@ -578,7 +578,7 @@ namespace Penneo.Connector
                 var request = PrepareRequest(url, data, method, options, page, perPage);
                 LogRequest(request, url, method.ToString());
 
-                RestResponse response = await _client.ExecuteAsync(request);
+                var response = await _client.ExecuteAsync(request).ConfigureAwait(false);
 
                 LogResponse(response, url, method.ToString());
 

--- a/Src/Penneo/Connector/ApiConnector.cs
+++ b/Src/Penneo/Connector/ApiConnector.cs
@@ -398,7 +398,7 @@ namespace Penneo.Connector
         /// </summary>
         public string LastResponseContent
         {
-            get { return _lastResponse != null ? _lastResponse.Content : null; }
+            get { return _lastResponse?.Content; }
         }
 
         #endregion

--- a/Src/Penneo/RestConnector.cs
+++ b/Src/Penneo/RestConnector.cs
@@ -31,9 +31,9 @@ namespace Penneo
         /// <summary>
         /// Send a custom request to the Penneo backend
         /// </summary>
-        public async Task<RestResponse> InvokeRequestAsync(string url, Dictionary<string, object> body = null, Method method = Method.Get, Dictionary<string, Dictionary<string, object>> options = null, int? page = null, int? perPage = null)
+        public Task<RestResponse> InvokeRequestAsync(string url, Dictionary<string, object> body = null, Method method = Method.Get, Dictionary<string, Dictionary<string, object>> options = null, int? page = null, int? perPage = null)
         {
-            return await _con.ApiConnector.CallServerAsync(url, body, method, options, page, perPage);
+            return _con.ApiConnector.CallServerAsync(url, body, method, options, page, perPage);
         }
 
         /// <summary>

--- a/Src/Penneo/Util/PaginationUtil.cs
+++ b/Src/Penneo/Util/PaginationUtil.cs
@@ -11,7 +11,7 @@ namespace Penneo.Util
         /// Parses a pagination Link header for next page, previous page, first page and number of objects per page
         /// Updates the given query result with the parse result
         /// </summary>
-        public static void ParseRepsonseHeadersForPagination<T>(string linkHeader, QueryResult<T> output)
+        public static void ParseResponseHeadersForPagination<T>(string linkHeader, QueryResult<T> output)
             where T : Entity
         {
             var relations = linkHeader.ToString().Split(',');

--- a/Src/PenneoTests/PaginationTests.cs
+++ b/Src/PenneoTests/PaginationTests.cs
@@ -14,7 +14,7 @@ namespace PenneoTests
         {
             var queryResult = new QueryResult<CaseFile>();
             const string linkHeader = "Link=<https://app.penneo.com/api/v1/casefiles?page=17&per_page=10>; rel=\"next\",<https://app.penneo.com/api/v1/casefiles?page=1&per_page=10>; rel=\"first\",<https://app.penneo.com/api/v1/casefiles?page=15&per_page=10>; rel=\"prev\"";
-            PaginationUtil.ParseRepsonseHeadersForPagination(linkHeader, queryResult);
+            PaginationUtil.ParseResponseHeadersForPagination(linkHeader, queryResult);
             Assert.AreEqual(17, queryResult.NextPage);
             Assert.AreEqual(15, queryResult.PrevPage);
             Assert.AreEqual(1, queryResult.FirstPage);


### PR DESCRIPTION
This PR simplifies the execution of some asynchronous calls. Because this is a library, it is recommended to execute the calls  appending `ConfigureAwait(continueOnCapturedContext: false)`. The benefits are:

- Improves performance: it does not require to execute the continuation on the original context or scheduler, removing the need to queue the continuation callback.
- Avoid deadlocks: if the caller calls the method on (for example) a UI thread, it can end up in a deadlock if the caller uses `.Result`. `ConfigureAwait(false)` avoids that problem.

There are some methods that are awaiting a task, to return the result. For example:

```
public async Task<string> SomeMethod() {
  var result = await CallSomeAsyncMethod();
  return result;
}
```

because we don't need to do anything with the result, we can just return the call:

```
public Task<string> SomeMethod() {
  return CallSomeAsyncMethod();
}
```

This slightly improves the performance of the codes by removing some boilerplate codes to handle the state machine of the async call. The other benefit is that simplifies the need to wrap the exception in an `AggregateException`

Finally, I fixed a typo and did a simple conditional expression merge:

`return r != null ? r.Object : null; --> return r?.Objectl;
`