### PR TITLE
Create the release 6.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-## [6.1.1] - 2024-03-05
+## [6.1.2] - 2024-03-06
 ### Added
 - Update the signer documentation example to showcase the usage of the SMS access control feature
+
+
+## [6.1.1] - 2024-04-05
+Skipped due to CI/CD issues
 
 
 ## [6.1.0] - 2023-08-23

--- a/Nuget/Penneo.nuspec
+++ b/Nuget/Penneo.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Penneo.SDK</id>
-    <version>6.1.1</version>
+    <version>6.1.2</version>
     <title>Penneo .Net SDK</title>
     <authors>Penneo</authors>
     <owners>Penneo</owners>

--- a/Src/Penneo/Info.cs
+++ b/Src/Penneo/Info.cs
@@ -5,6 +5,6 @@ namespace Penneo
         /// <summary>
         /// The version of the SDK. This should be updated on each release.
         /// </summary>
-        public const string Version = "6.1.1";
+        public const string Version = "6.1.2";
     }
 }

--- a/Src/Penneo/Penneo.csproj
+++ b/Src/Penneo/Penneo.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0;net48</TargetFrameworks>
     
-    <Version>6.1.1</Version>
+    <Version>6.1.2</Version>
     <PackageId>Penneo.SDK</PackageId>
     <OutputType>Library</OutputType>
     <PackageLicenseUrl>https://github.com/Penneo/sdk-net/blob/master/license.txt</PackageLicenseUrl>


### PR DESCRIPTION
The creation of the version 6.1.1 failed because of permissions issues during the publication of the package to NuGet. 

Since we cannot re-run the CI/CD easily, we are going to skip this version and publish 6.1.2