### PR TITLE
SIGN-2009/support investigation net sdk query crash/0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [7.0.1] - 2024-06-25
+### Fixed
+- Fixed an issue where queries would fail if the query result only returned a single page
+
 ## [7.0.0] - 2024-05-15
 - Updated RestSharp from `108.0.2` to `110.2.0`
 

--- a/Src/Penneo/(Query)/Query.cs
+++ b/Src/Penneo/(Query)/Query.cs
@@ -156,7 +156,7 @@ namespace Penneo
                 {
                     var linkHeader =
                         findByResult.Response.Headers.FirstOrDefault(x => x.Name.Equals("link", StringComparison.OrdinalIgnoreCase));
-                    if (linkHeader != null && linkHeader.Value != null)
+                    if (linkHeader != null && !String.IsNullOrEmpty(linkHeader.Value as string))
                     {
                         PaginationUtil.ParseResponseHeadersForPagination(linkHeader.Value.ToString(), output);
                     }


### PR DESCRIPTION
A recent change in the public api means that queries that only return a
single page a result will have an empty link header. We were only
checking if the link header was null. The application would therefore
crash since it would try an parse an empty linkHeader.Value. We fix this
by also checking if linkHeader.Value is an empty string