### PR TITLE
Updating dependencies

### DIFF
--- a/Nuget/Penneo.nuspec
+++ b/Nuget/Penneo.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Penneo.SDK</id>
-    <version>6.1.2</version>
+    <version>6.1.3</version>
     <title>Penneo .Net SDK</title>
     <authors>Penneo</authors>
     <owners>Penneo</owners>
@@ -14,9 +14,9 @@
     <copyright>Copyright 2014</copyright>
     <tags>Penneo sign signing digital</tags>
     <dependencies>
-      <dependency id="RestSharp" version="108.0.2" />
+      <dependency id="RestSharp" version="112.0.0" />
       <dependency id="Newtonsoft.Json" version="13.0.2" />
-      <dependency id="System.Net.Http" version="4.3.3" />
+      <dependency id="System.Net.Http" version="4.3.4" />
     </dependencies>
     <releaseNotes>
       /// Appveyor pre-build script will automatically add the latest release notes from CHANGELOG.md

--- a/Src/Penneo/Penneo.csproj
+++ b/Src/Penneo/Penneo.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp" Version="112.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'== 'net48'">

--- a/Src/PenneoTests/PenneoTests.csproj
+++ b/Src/PenneoTests/PenneoTests.csproj
@@ -15,11 +15,11 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="NUnit.Console" Version="3.17.0" />
-        <PackageReference Include="NUnit" Version="4.1.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-        <PackageReference Include="FakeItEasy" Version="8.2.0" />
+        <PackageReference Include="NUnit.Console" Version="3.18.1" />
+        <PackageReference Include="NUnit" Version="4.2.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="FakeItEasy" Version="8.3.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="RestSharp" Version="112.0.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />

--- a/Src/PenneoTests/PenneoTests.csproj
+++ b/Src/PenneoTests/PenneoTests.csproj
@@ -21,7 +21,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
         <PackageReference Include="FakeItEasy" Version="8.2.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="RestSharp" Version="110.2.0" />
+        <PackageReference Include="RestSharp" Version="112.0.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
     <Choose>


### PR DESCRIPTION
Changes:

- Updating the `nuget.spec` file, as we were referencing old versions of the dependencies
- Updating `RestSharp`, as [Dependabot](https://github.com/Penneo/sdk-net/security/dependabot) found some vulnerabilities
- Update all the tests packages to their latest verison