### PR TITLE
Update packages and adapt to new RestSharp.IAuthenticator interface (blocking)

### DIFF
--- a/Src/Penneo/Connector/WSSEAuthenticator.cs
+++ b/Src/Penneo/Connector/WSSEAuthenticator.cs
@@ -1,9 +1,10 @@
-﻿using System;
+﻿using RestSharp;
+using RestSharp.Authenticators;
+using System;
 using System.Security.Cryptography;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
-using RestSharp;
-using RestSharp.Authenticators;
 
 namespace Penneo.Connector
 {
@@ -48,7 +49,7 @@ namespace Penneo.Connector
         /// <summary>
         /// Adds WSSE security headers to the request
         /// </summary>        
-        public ValueTask Authenticate(IRestClient client, RestRequest request)
+        public ValueTask Authenticate(IRestClient client, RestRequest request, CancellationToken cancellationToken = default(CancellationToken))
         {
             var created = DateTime.Now.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ssZ");
             var nonce = Base64Encode(Noncer());

--- a/Src/Penneo/Penneo.csproj
+++ b/Src/Penneo/Penneo.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net10.0;netstandard2.0;net48</TargetFrameworks>
+    <TargetFrameworks>net9.0;netstandard2.0;net48</TargetFrameworks>
     
     <Version>8.0.1</Version>
     <PackageId>Penneo.SDK</PackageId>

--- a/Src/Penneo/Penneo.csproj
+++ b/Src/Penneo/Penneo.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0;net48</TargetFrameworks>
+    <TargetFrameworks>net10.0;netstandard2.0;net48</TargetFrameworks>
     
     <Version>8.0.1</Version>
     <PackageId>Penneo.SDK</PackageId>
@@ -42,8 +42,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="RestSharp" Version="112.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="RestSharp" Version="114.0.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'== 'net48'">

--- a/Src/PenneoTests/PenneoTests.csproj
+++ b/Src/PenneoTests/PenneoTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net10.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     </PropertyGroup>

--- a/Src/PenneoTests/PenneoTests.csproj
+++ b/Src/PenneoTests/PenneoTests.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>false</IsPackable>
         <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     </PropertyGroup>
@@ -15,13 +15,13 @@
         <WarningLevel>4</WarningLevel>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="NUnit.Console" Version="3.18.1" />
-        <PackageReference Include="NUnit" Version="4.2.2" />
-        <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-        <PackageReference Include="FakeItEasy" Version="8.3.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-        <PackageReference Include="RestSharp" Version="112.0.0" />
+        <PackageReference Include="NUnit.Console" Version="3.22.0" />
+        <PackageReference Include="NUnit" Version="4.5.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="FakeItEasy" Version="9.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+        <PackageReference Include="RestSharp" Version="114.0.0" />
         <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
     <Choose>


### PR DESCRIPTION
After updating the reference to RestSharp v114.0, we  encountered the following error in the Penneo library :
System.TypeLoadException: 'Method 'Authenticate' in type 'Penneo.Connector.WSSEAuthenticator' from assembly 'Penneo, Version=8.0.1.0, Culture=neutral, PublicKeyToken=7063bba8a75d5be2' does not have an implementation.'

This is a consequence of the breaking changes introduced in v114.0 of RestSharp, requiring the recompilation of libraries that uses it.

Along with the update of RestSharp, I updated other libraries also, one of them being marked as vulnerable.

Should solve issue [192](https://github.com/Penneo/sdk-net/issues/192)